### PR TITLE
Render profile images for DMs in the sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "electron-devtools-installer": "^2.0.1",
     "electron-remote": "^1.1.2",
     "keycode": "^2.1.8",
+    "lodash.pick": "4.4.0",
     "lru-cache": "^4.0.2",
     "material-ui": "^0.16.7",
     "react": "^15.4.2",

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -4,5 +4,6 @@ declare module 'electron-devtools-installer';
 declare module 'electron-devtools-installer';
 declare module 'electron-remote';
 declare module 'dotenv';
+declare module 'lodash.pick';
 declare module 'material-ui/*';
 declare module 'react-virtualized';

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,3 +1,8 @@
+declare module 'electron-compile';
+declare module 'electron-debug';
+declare module 'electron-devtools-installer';
+declare module 'electron-devtools-installer';
+declare module 'electron-remote';
+declare module 'dotenv';
 declare module 'material-ui/*';
 declare module 'react-virtualized';
-declare module 'electron-remote';

--- a/src/channel-list-item.tsx
+++ b/src/channel-list-item.tsx
@@ -35,7 +35,7 @@ export class ChannelViewModel extends Model {
 
     this.when('model')
       .filter((c: any) => isDM(c.value))
-      .flatMap((c: any) => this.store.users.listen(c.value.user_id))
+      .switchMap((c: any) => this.store.users.listen(c.value.user_id))
       .map((res) => res.user.profile.image_48)
       .toProperty(this, 'profileImage');
 

--- a/src/channel-list-item.tsx
+++ b/src/channel-list-item.tsx
@@ -3,11 +3,13 @@ import * as React from 'react';
 import Avatar from 'material-ui/Avatar';
 import { ListItem } from 'material-ui/List';
 import Star from 'material-ui/svg-icons/toggle/star';
-import { pinkA200 } from 'material-ui/styles/colors';
+import { grey700, pinkA200, transparent } from 'material-ui/styles/colors';
 
 import { SimpleView } from './lib/view';
 import { fromObservable, notify, Model } from './lib/model';
+import { Store } from './lib/store';
 import { Updatable } from './lib/sparse-map';
+import { isDM } from './channel-utils';
 
 import { ChannelBase } from './lib/models/api-shapes';
 
@@ -17,11 +19,12 @@ export class ChannelViewModel extends Model {
 
   @fromObservable model: ChannelBase;
   @fromObservable displayName: string;
+  @fromObservable profileImage: string;
   @fromObservable mentions: number;
   @fromObservable highlighted: boolean;
   @fromObservable starred: boolean;
 
-  constructor(model: Updatable<ChannelBase>) {
+  constructor(private readonly store: Store, model: Updatable<ChannelBase>) {
     super();
 
     model.toProperty(this, 'model');
@@ -29,6 +32,12 @@ export class ChannelViewModel extends Model {
     this.when('model.name')
       .map((n: any) => this.getDisplayName(n.value))
       .toProperty(this, 'displayName');
+
+    this.when('model')
+      .filter((c: any) => isDM(c.value))
+      .flatMap((c: any) => this.store.users.listen(c.value.user_id))
+      .map((res) => res.user.profile.image_48)
+      .toProperty(this, 'profileImage');
 
     this.when('model.is_starred')
       .map((starred: any) => starred.value)
@@ -52,12 +61,37 @@ export class ChannelListItem extends SimpleView<ChannelViewModel> {
   render() {
     const viewModel = this.props.viewModel;
     const fontWeight = viewModel.highlighted ? 'bold' : 'normal';
-    const starIcon = viewModel.starred ?
-      <Star style={{ top: '-8px' }} /> :
-      null;
+    const offsetStyle = { top: '4px' };
 
-    const badge = viewModel.mentions > 0 ? (
-      <Avatar backgroundColor={pinkA200} size={24} style={{ top: '4px' }}>
+    let leftAvatar = null;
+    if (viewModel.starred) {
+      leftAvatar = <Star style={offsetStyle} color={grey700}/>;
+    } else if (viewModel.profileImage) {
+      leftAvatar = (
+        <Avatar
+          src={viewModel.profileImage}
+          style={offsetStyle}
+          size={24}
+        />
+      );
+    } else {
+      leftAvatar = (
+        <Avatar
+          color={grey700} backgroundColor={transparent}
+          style={offsetStyle}
+          size={24}
+        >
+          #
+        </Avatar>
+      );
+    }
+
+    const mentionsBadge = viewModel.mentions > 0 ? (
+      <Avatar
+        backgroundColor={pinkA200}
+        style={offsetStyle}
+        size={24}
+      >
         {viewModel.mentions}
       </Avatar>
     ) : null;
@@ -65,8 +99,8 @@ export class ChannelListItem extends SimpleView<ChannelViewModel> {
     return (
       <ListItem
         primaryText={viewModel.displayName}
-        leftIcon={starIcon}
-        rightAvatar={badge}
+        leftAvatar={leftAvatar}
+        rightAvatar={mentionsBadge}
         style={{ fontWeight }}
         innerDivStyle={{ padding: '8px 8px 8px 60px' }}
       />

--- a/src/channel-list-item.tsx
+++ b/src/channel-list-item.tsx
@@ -13,16 +13,8 @@ import { isDM } from './channel-utils';
 
 import { ChannelBase } from './lib/models/api-shapes';
 
-export interface ChannelViewModelArgs {
-  store: Store;
-  model: Updatable<ChannelBase>;
-  onUnsubscribe: Function;
-}
-
 @notify('isSelected')
 export class ChannelViewModel extends Model {
-  store: Store;
-  onUnsubscribe: Function;
   isSelected: boolean;
 
   @fromObservable model: ChannelBase;
@@ -33,10 +25,9 @@ export class ChannelViewModel extends Model {
   @fromObservable highlighted: boolean;
   @fromObservable starred: boolean;
 
-  constructor({ store, model, onUnsubscribe }: ChannelViewModelArgs) {
+  constructor(public readonly store: Store, model: Updatable<ChannelBase>) {
     super();
     this.store = store;
-    this.onUnsubscribe = onUnsubscribe;
 
     model.toProperty(this, 'model');
 
@@ -65,11 +56,6 @@ export class ChannelViewModel extends Model {
     this.when('mentions', 'model.has_unreads',
       (mentions, hasUnreads) => mentions.value > 0 || hasUnreads.value)
       .toProperty(this, 'highlighted');
-  }
-
-  unsubscribe() {
-    this.onUnsubscribe();
-    super.unsubscribe();
   }
 
   private getDisplayName(name: string) {

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -5,7 +5,7 @@ import { AutoSizer, List } from 'react-virtualized';
 import { SimpleView } from './lib/view';
 import { fromObservable, Model } from './lib/model';
 import { Store, ChannelList } from './lib/store';
-import { channelSort } from './utils';
+import { channelSort } from './channel-utils';
 
 import { ChannelBase } from './lib/models/api-shapes';
 import { ChannelViewModel, ChannelListItem } from './channel-list-item';
@@ -42,7 +42,7 @@ export class ChannelListView extends SimpleView<ChannelListViewModel> {
         key={item.value.id}
         style={style}
       >
-        <ChannelListItem viewModel={new ChannelViewModel(item)} />
+        <ChannelListItem viewModel={new ChannelViewModel(this.viewModel.store, item)} />
       </div>
     );
   }

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -33,16 +33,34 @@ export class ChannelListViewModel extends Model {
 }
 
 export class ChannelListView extends SimpleView<ChannelListViewModel> {
+  private readonly viewModelCache: { [key: number]: ChannelViewModel } = {};
+
+  getOrCreateViewModel(index: number) {
+    if (!this.viewModelCache[index]) {
+      const channel = this.viewModel.orderedChannels[index];
+      const onUnsubscribe = () => {
+        delete this.viewModelCache[index];
+      };
+
+      this.viewModelCache[index] = new ChannelViewModel({
+        store: this.viewModel.store,
+        model: channel,
+        onUnsubscribe
+      });
+    }
+    return this.viewModelCache[index];
+  }
+
   rowRenderer(opts: any): JSX.Element {
     const { index, style } = opts;
-    const item = this.viewModel.orderedChannels[index];
+    const itemViewModel = this.getOrCreateViewModel(index);
 
     return (
       <div
-        key={item.value.id}
+        key={itemViewModel.id}
         style={style}
       >
-        <ChannelListItem viewModel={new ChannelViewModel(this.viewModel.store, item)} />
+        <ChannelListItem viewModel={itemViewModel} />
       </div>
     );
   }

--- a/src/channel-utils.ts
+++ b/src/channel-utils.ts
@@ -13,6 +13,6 @@ export function channelSort(
   return a.name.localeCompare(b.name);
 }
 
-export function isDM(channel: ChannelBase) {
-  return channel.id[0] === 'D';
+export function isDM(channel: ChannelBase): boolean {
+  return !!channel.id && channel.id[0] === 'D';
 }

--- a/src/index.html
+++ b/src/index.html
@@ -12,14 +12,14 @@
     </style>
   </head>
 
-  <body style="overflow: hidden; background-color: rgba(0,0,0,0); margin: 0">
+  <body style="overflow: hidden; background-color: rgba(0,0,0,0); margin: 0; user-select: none;">
     <div id="app" style="position: absolute; width: 100vw; height: 100vh"></div>
   </body>
 
   <script type="text/typescript">
   if (!process.execPath.match(/[\\/]electron-prebuilt/)) {
     process.env.NODE_ENV = 'production';
-  }   
+  }
   </script>
 
   <script type="text/tsx">

--- a/src/lib/collection-view.tsx
+++ b/src/lib/collection-view.tsx
@@ -1,0 +1,63 @@
+import * as pick from 'lodash.pick';
+import * as React from 'react';
+import { AutoSizer, List } from 'react-virtualized';
+
+import { Model } from './model';
+import { View, HasViewModel } from './view';
+
+export interface CollectionViewProps<T extends Model> extends HasViewModel<T> {
+  viewModel: T;
+  rowHeight: number;
+  width?: number;
+  height?: number;
+  disableWidth?: boolean;
+  disableHeight?: boolean;
+}
+
+export abstract class CollectionView<
+  T extends Model,
+  TChild extends Model
+> extends View<T, CollectionViewProps<T>> {
+
+  private readonly viewModelCache: { [key: number]: TChild } = {};
+
+  abstract viewModelFactory(index: number): TChild;
+  abstract renderItem(viewModel: TChild): JSX.Element;
+  abstract rowCount(): number;
+
+  getOrCreateViewModel(index: number): TChild {
+    if (!this.viewModelCache[index]) {
+      const itemViewModel = this.viewModelFactory(index);
+      itemViewModel.addTeardown(() => delete this.viewModelCache[index]);
+      this.viewModelCache[index] = itemViewModel;
+    }
+    return this.viewModelCache[index];
+  }
+
+  rowRenderer({ index, style }: { index: number, style: React.CSSProperties }) {
+    return (
+      <div key={index} style={style}>
+        {this.renderItem(this.getOrCreateViewModel(index))}
+      </div>
+    );
+  }
+
+  render() {
+    const autoSizerProps = pick(this.props, ['disableWidth', 'disableHeight']);
+    const listProps = pick(this.props, ['width', 'height', 'rowHeight']);
+
+    return (
+      <AutoSizer {...autoSizerProps}>
+        {({ width, height }: { width: number, height: number }) => (
+          <List
+            width={width}
+            height={height}
+            {...listProps}
+            rowRenderer={this.rowRenderer.bind(this)}
+            rowCount={this.rowCount()}
+          />
+        )}
+      </AutoSizer>
+    );
+  }
+}

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -132,6 +132,10 @@ export class Model {
     this.innerDisp.unsubscribe();
   }
 
+  addTeardown(teardown: void | Function) {
+    this.innerDisp.add(teardown);
+  }
+
   when<TRet>(prop1: string): Observable<TRet>;
   when<TRet>(prop1: string, prop2: string, sel: WhenSelector<TRet>): Observable<TRet>;
   when<TRet>(prop1: string, prop2: string, prop3: string, sel: WhenSelector<TRet>): Observable<TRet>;

--- a/src/lib/models/api-call.ts
+++ b/src/lib/models/api-call.ts
@@ -1,12 +1,18 @@
 import { RecursiveProxyHandler } from 'electron-remote';
 import { Observable } from 'rxjs/Observable';
 
+import { User } from './api-shapes';
+
 import '../standard-operators';
 import 'rxjs/add/observable/dom/ajax';
 
 export interface ApiCall {
   ok: boolean;
   error?: string;
+}
+
+export interface UserResponse extends ApiCall {
+  user: User;
 }
 
 export function createApi(token?: string): any {

--- a/src/lib/models/api-shapes.ts
+++ b/src/lib/models/api-shapes.ts
@@ -28,7 +28,6 @@ export interface UsersCounts {
 export interface DirectMessage extends ChannelBase {
   user: string;
   is_open: boolean;
-  is_im: boolean;
 }
 
 export interface Group extends ChannelBase {
@@ -152,6 +151,12 @@ export interface Profile {
   always_active: boolean;
   bot_id: string;
   fields: { [name: string]: UserProfileField };
+
+  image_24: string;
+  image_32: string;
+  image_48: string;
+  image_72: string;
+  image_192: string;
 }
 
 export interface SharedUserProfile {

--- a/src/lib/standard-operators.ts
+++ b/src/lib/standard-operators.ts
@@ -8,6 +8,7 @@ import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/finally';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/observeOn';
 import 'rxjs/add/operator/publish';
 import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/switch';

--- a/src/lib/standard-operators.ts
+++ b/src/lib/standard-operators.ts
@@ -11,4 +11,5 @@ import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/publish';
 import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/switch';
+import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/takeUntil';

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs/Observable';
 
-import { Updatable } from './sparse-map';
-import { createApi } from './models/api-call';
+import { InMemorySparseMap, SparseMap, Updatable } from './sparse-map';
+import { createApi, UserResponse } from './models/api-call';
 import { Channel, ChannelBase, Group, DirectMessage, UsersCounts } from './models/api-shapes';
 
 import './standard-operators';
@@ -11,10 +11,14 @@ export type ChannelList = Array<Updatable<ChannelBase>>;
 export class Store {
   api: any;
   channels: Updatable<ChannelList>;
+  users: SparseMap<string, UserResponse>;
 
   constructor(token?: string) {
     this.api = createApi(token);
     this.channels = new Updatable<ChannelList>(() => Observable.of([]));
+    this.users = new InMemorySparseMap<string, UserResponse>((user) => {
+      return this.api.users.info({ user });
+    });
   }
 
   async fetchInitialChannelList(): Promise<void> {

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -1,6 +1,7 @@
 import { Observable } from 'rxjs/Observable';
 import { AsyncSubject } from 'rxjs/AsyncSubject';
 import { Subject } from 'rxjs/Subject';
+import { asap } from 'rxjs/scheduler/asap';
 
 import * as React from 'react';
 
@@ -97,9 +98,10 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
     this.lifecycle.didMount
       .flatMap(() => this.viewModel.changed)
       .takeUntil(this.lifecycle.willUnmount)
-      .subscribe(() => this.forceUpdate());
+      .observeOn(asap)
+      .subscribe(() => { if (this.viewModel) { this.forceUpdate(); } });
 
-    this.lifecycle.willUnmount.subscribe(() => { if (this.viewModel) this.viewModel.unsubscribe(); });
+    this.lifecycle.willUnmount.subscribe(() => { if (this.viewModel) this.viewModel.unsubscribe(); this.viewModel = null; });
   }
 
   componentWillMount() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ app.on('window-all-closed', () => {
 
 app.on('ready', async () => {
   mainWindow = new BrowserWindow({
-    width: 800, height: 600,
+    width: 1024, height: 768,
   });
 
   mainWindow.loadURL(`file://${__dirname}/index.html`);

--- a/src/slack-app.tsx
+++ b/src/slack-app.tsx
@@ -99,7 +99,7 @@ export class SlackApp extends SimpleView<SlackAppModel> {
     };
 
     const channelListView = vm.isOpen ?
-      <ChannelListView viewModel={new ChannelListViewModel(vm.store)} /> :
+      <ChannelListView viewModel={vm.channelList} /> :
       null;
 
     return (

--- a/src/slack-app.tsx
+++ b/src/slack-app.tsx
@@ -98,9 +98,12 @@ export class SlackApp extends SimpleView<SlackAppModel> {
       transition: 'margin-left: 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms'
     };
 
-    const channelListView = vm.isOpen ?
-      <ChannelListView viewModel={vm.channelList} /> :
-      null;
+    const channelListView = vm.isOpen ? (
+      <ChannelListView
+        viewModel={vm.channelList}
+        rowHeight={32}
+        width={300} />
+      ) : null;
 
     return (
       <MuiThemeProvider muiTheme={slackTheme}>


### PR DESCRIPTION
This PR renders profile images for users in the sidebar. I found that we're creating new view-models in every `render` call, which is not only unnecessary work but also breaks our rule of matching view to view-model lifecycles. To workaround this I made a new `View` called `CollectionView`:

``` ts
export abstract class CollectionView<
  T extends Model,
  TChild extends Model
> extends View<T, CollectionViewProps<T>> {

  private readonly viewModelCache: { [key: number]: TChild } = {};

  abstract viewModelFactory(index: number): TChild;
  abstract renderItem(viewModel: TChild): JSX.Element;
  abstract rowCount(): number;
  ...
}
```

`CollectionView` lets one view-model maintain a collection of child view-models, and caches them until the corresponding child view is unmounted.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2C3t2n3W0g2T1E39320S/Screen%20Recording%202017-02-26%20at%2005.10%20PM.gif?X-CloudApp-Visitor-Id=1741631&v=a106d8eb)