### PR TITLE
Add a heap profile to every PR

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+runtime = electron
+target = 1.6.1
+target_arch = x64
+disturl = https://atom.io/download/atom-shell
+tag-version-prefix = ""
+build_from_source = true
+save-exact=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,5 @@ install:
   - npm install -g surf-build@latest electron-forge@latest
 
 script:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then surf-build -n surf-travis-linux; fi 
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then surf-build -n surf-travis-macos; fi 
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then surf-build -n surf-travis-linux -s "$TRAVIS_COMMIT"; fi 
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then surf-build -n surf-travis-macos -s "$TRAVIS_COMMIT"; fi 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ addons:
       - openbox 
       - lightdm
       - curl
+      - rpm
       - wget
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,5 @@ install:
   - npm install -g surf-build@latest electron-forge@latest
 
 script:
-  - surf-build -n "surf-travis-$TRAVIS_OS_NAME"
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then surf-build -n surf-travis-linux; fi 
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then surf-build -n surf-travis-macos; fi 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ os:
   - linux
   - osx
 
+env:
+  - DEBUG='surf-build:*, surf:*'
+
 cache:
   directories:
     - $HOME/.npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,11 @@ node_js:
   - "6.3.0"
 compiler:
   - clang
+sudo: required
 
 os:
   - linux
   - osx
-
-env:
-  - DEBUG="*,-babel"
 
 cache:
   directories:

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,9 @@
 set -ex
 npm install
 
-if [ "$(uname)" = "Darwin" ];
-then
+#if [ "$(uname)" = "Darwin" ];
+#then
   npm test
-fi
+#fi
 
 electron-forge make

--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,10 @@
 
 set -ex
 npm install
-
-#if [ "$(uname)" = "Darwin" ];
-#then
-  npm test
-#fi
+npm test
 
 electron-forge make
+
+if [ -z "$SURF_ARTIFACT_DIR" ]; then
+	mv ./out/make/* "$SURF_ARTIFACT_DIR"
+fi

--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,10 @@
 
 set -ex
 npm install
-npm test
+
+if [ "$(uname)" = "Darwin" ];
+then
+  npm test
+fi
+
 electron-forge make

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,10 @@ set -ex
 npm install
 npm test
 
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 electron-forge make
 
-if [ -z "$SURF_ARTIFACT_DIR" ]; then
-	mv ./out/make/* "$SURF_ARTIFACT_DIR"
+if [ -n "$SURF_ARTIFACT_DIR" ]; then
+	cp $ROOT/out/make/* "$SURF_ARTIFACT_DIR"
 fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,4 +42,5 @@ RUN useradd -ms /bin/bash surf
 ENV HOME=/home/surf
 USER surf
 
+ENV SURF_REPO=https://github.com/paulcbetts/trickline
 CMD surf-run -n 'surf-docker' -r 'https://github.com/paulcbetts/trickline'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,43 @@
+# Base docker image
+FROM node:6.5.0
+
+ENV BUILD_NAME=surf
+
+RUN npm install -g surf-build@1.0.2 electron-forge@2.8.1
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    fakeroot \
+    clang \
+    cmake \
+    libgnome-keyring-dev \
+    libnss3 \
+    libgtk2.0-dev \
+    libnotify-dev \
+    libdbus-1-dev \
+    libxrandr-dev \
+    libxext-dev \
+    libxss-dev \
+    libgconf2-dev \
+    libasound2-dev \
+    libcap-dev \
+    libcups2-dev \
+    libXtst-dev \
+    libcurl4-openssl-dev \
+    libxkbfile-dev \
+    rpm \
+    curl \
+    wget \
+    xvfb \
+    --no-install-recommends
+
+## NB: npm post-install hates running as root :-/
+RUN useradd -ms /bin/bash surf
+
+ENV HOME=/home/surf
+USER surf
+
+CMD surf-run -n 'surf-docker' -r 'https://github.com/paulcbetts/trickline'

--- a/docker/surf-build-current.ts
+++ b/docker/surf-build-current.ts
@@ -1,0 +1,45 @@
+import * as path from 'path';
+import * as os from 'os';
+import 'rxjs';
+
+import { spawn, spawnPromise } from 'spawn-rx';
+import { config } from 'dotenv';
+
+config();
+
+const rootDir = path.dirname(require.resolve('../package.json'));
+
+export async function spawnNoisyPromise(cmd, args, opts) {
+  const ret = spawn(cmd, args, opts);
+
+  return ret
+    .do(x => console.log(x))
+    .reduce((acc, x) => true)
+    .toPromise();
+}
+
+export async function main() {
+  const ourSha = await spawnPromise('git', ['rev-parse', 'HEAD']);
+
+  console.log("Building Docker Image...");
+  await spawnNoisyPromise('docker', ['build', '-t', 'surf-trickline', '.'], {cwd: path.join(rootDir, 'docker')});
+
+  console.log("Running build...");
+  await spawnNoisyPromise('docker', [
+    'run',
+    '-e', `GITHUB_TOKEN=${process.env.GITHUB_TOKEN}`,
+    'surf-trickline',
+    'surf-build',
+    '-s', ourSha,
+    '-n', `surf-docker-${os.hostname()}`]);
+}
+
+if (process.mainModule === module) {
+    main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error(e.message);
+      console.error(e.stack);
+      process.exit(-1);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/main.ts",
   "scripts": {
     "start": "electron-forge start",
+    "clean-build": "ts-node -D ./docker/surf-build-current",
     "test-renderer": "xvfb-maybe electron-mocha --renderer --watch-extensions tsx,ts './test/**/*.{js,ts}'",
     "dtest": "electron-mocha --renderer --interactive --watch-extensions tsx,ts './test/**/*.{js,ts}'",
     "test": "npm run test-renderer",
@@ -40,7 +41,8 @@
     "react-hot-loader": "^3.0.0-beta.6",
     "react-tap-event-plugin": "^2.0.1",
     "react-virtualized": "^9.0.0",
-    "rxjs": "^5.0.2"
+    "rxjs": "^5.0.2",
+    "spawn-rx": "2.0.8"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
@@ -65,6 +67,7 @@
     "eslint": "~3.12.2",
     "eslint-plugin-react": "^6.8.0",
     "react-hot-loader": "^3.0.0-beta.6",
+    "ts-node": "2.1.0",
     "tslint": "^4.2.0",
     "typescript": "~2.1.4",
     "xvfb-maybe": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/paulcbetts/trickline#readme",
   "dependencies": {
+    "@paulcbetts/v8-profiler": "5.6.6",
     "@types/chai": "^3.4.34",
     "@types/debug": "0.0.29",
     "@types/electron": "^1.4.31",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "cross-env": "^3.1.4",
     "csslint": "^1.0.5",
     "electron-compilers": "^5.5.1",
-    "electron-debug": "^1.1.0",
     "electron-mocha": "^3.3.0",
     "electron-prebuilt-compile": "1.6.0",
     "esdoc": "^0.5.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,6 @@ app.on('ready', async () => {
     await installExtension(REACT_DEVELOPER_TOOLS);
     mainWindow.webContents.openDevTools();
   } else {
-    mainWindow.webContents.openDevTools();
+    if (!process.env['TRICKLINE_HEAPSHOT_AND_BAIL']) mainWindow.webContents.openDevTools();
   }
 });

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -1,0 +1,27 @@
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+let v8profiler: any = null;
+
+export function takeHeapSnapshot() {
+  v8profiler = v8profiler || require('@paulcbetts/v8-profiler');
+
+  const snapshot = v8profiler.takeSnapshot();
+  const target = path.join(os.tmpdir(), `trickline-Heapshot-${(new Date()).toISOString()}.json`);
+
+  let ret = new Promise((res,rej) => {
+    snapshot.export()
+      .pipe(fs.createWriteStream(target))
+      .on('finish', res(target))
+      .on('error', rej);
+  });
+
+  return ret.then((ret) => {
+    snapshot.delete();
+    return ret;
+  }, (e) => {
+    snapshot.delete();
+    return Promise.reject(e);
+  });
+}


### PR DESCRIPTION
PRs should all capture a heap profile of the app running, so that we can compare it over time.

Blocked on https://github.com/electron/electron/issues/8791 :cry:

This PR also adds a command `npm run clean-build` that, if you have Docker installed, will create a clean build, run the tests, and push them up to your current commit as a GitHub status. This PR also gets tests running on Linux as well as gets build artifacts working on all platforms