### PR TITLE
Measure startup perf as a part of every PR

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,14 @@ npm test
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-electron-forge make
+electron-forge package
 
 if [ -n "$SURF_ARTIFACT_DIR" ]; then
 	cp $ROOT/out/make/* "$SURF_ARTIFACT_DIR"
+
+	TRICKLINE_BIN="$( $ROOT/node_modules/.bin/ts-node ./script/find-trickline-exe.ts)"
+	TRICKLINE_HEAPSHOT_AND_BAIL=1 $ROOT/node_modules/.bin/xvfb-maybe $TRICKLINE_BIN
+
+	$ROOT/node_modules/.bin/bigrig -f $SURF_ARTIFACT_DIR/trickline-timeline*.json > $SURF_ARTIFACT_DIR/bigrig.json
+	$ROOT/node_modules/.bin/bigrig -f $SURF_ARTIFACT_DIR/trickline-timeline*.json --pretty-print
 fi

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,11 @@ npm test
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+#electron-forge make
 electron-forge package
 
 if [ -n "$SURF_ARTIFACT_DIR" ]; then
-	cp $ROOT/out/make/* "$SURF_ARTIFACT_DIR"
+	#cp $ROOT/out/make/* "$SURF_ARTIFACT_DIR"
 
 	TRICKLINE_BIN="$( $ROOT/node_modules/.bin/ts-node ./script/find-trickline-exe.ts)"
 	TRICKLINE_HEAPSHOT_AND_BAIL=1 $ROOT/node_modules/.bin/xvfb-maybe $TRICKLINE_BIN

--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,10 @@ npm test
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-#electron-forge make
-electron-forge package
+electron-forge make
 
 if [ -n "$SURF_ARTIFACT_DIR" ]; then
-	#cp $ROOT/out/make/* "$SURF_ARTIFACT_DIR"
+	cp $ROOT/out/make/* "$SURF_ARTIFACT_DIR"
 
 	TRICKLINE_BIN="$( $ROOT/node_modules/.bin/ts-node ./script/find-trickline-exe.ts)"
 	TRICKLINE_HEAPSHOT_AND_BAIL=1 $ROOT/node_modules/.bin/xvfb-maybe $TRICKLINE_BIN

--- a/docker/surf-build-current.ts
+++ b/docker/surf-build-current.ts
@@ -28,6 +28,7 @@ export async function main() {
   await spawnNoisyPromise('docker', [
     'run',
     '-e', `GITHUB_TOKEN=${process.env.GITHUB_TOKEN}`,
+    '-e', `SLACK_API_TOKEN=${process.env.SLACK_API_TOKEN}`,
     'surf-trickline',
     'surf-build',
     '-s', ourSha,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "electron-compile": "^6.1.2",
     "electron-debug": "^1.1.0",
     "electron-devtools-installer": "^2.0.1",
-    "electron-remote": "^1.1.2",
+    "electron-remote": "1.1.2",
     "keycode": "^2.1.8",
     "lru-cache": "^4.0.2",
     "material-ui": "^0.16.7",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-env": "^1.1.5",
+    "bigrig": "1.3.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "cross-env": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/paulcbetts/trickline#readme",
   "dependencies": {
-    "@paulcbetts/v8-profiler": "5.6.6",
     "@types/chai": "^3.4.34",
     "@types/debug": "0.0.29",
     "@types/electron": "^1.4.31",

--- a/script/find-trickline-exe.ts
+++ b/script/find-trickline-exe.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const rootDir = path.dirname(require.resolve('../package.json'));
+
+if (!fs.existsSync(path.join(rootDir, 'out'))) {
+  throw new Error('Package the app first!');
+}
+
+const dirName = fs.readdirSync(path.join(rootDir, 'out'))
+  .find(x => !!x.match(/^.+-.+-.+$/));
+
+if (!dirName) {
+  throw new Error('Package the app first!');
+}
+
+const [packageId, platform] = dirName.split('-');
+switch(platform) {
+case 'win32':
+  console.log(path.join(rootDir, 'out', dirName, `${packageId}.exe`));
+  break;
+case 'linux':
+  console.log(path.join(rootDir, 'out', dirName, `${packageId}`));
+  break;
+case 'darwin':
+  console.log(path.join(rootDir, 'out', dirName, `${packageId}.app`, 'Contents', 'MacOS', packageId));
+  break;
+}

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -1,19 +1,34 @@
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
+import {contentTracing} from 'electron';
 
 let v8profiler: any = null;
+
+function getTargetFilename(type) {
+  const targetDir = process.env['SURF_ARTIFACT_DIR'] || os.tmpdir();
+  const file = `trickline-${type}-${(new Date()).toISOString()}.json`.replace(/:/g, '-');
+
+  return path.join(targetDir, file);
+}
 
 export function takeHeapSnapshot() {
   v8profiler = v8profiler || require('@paulcbetts/v8-profiler');
 
   const snapshot = v8profiler.takeSnapshot();
-  const target = path.join(os.tmpdir(), `trickline-Heapshot-${(new Date()).toISOString()}.json`);
+  const target = getTargetFilename('heapshot');
 
-  let ret = new Promise((res,rej) => {
+  let ret = new Promise((res, rej) => {
+    let writeStream;
+    try {
+      writeStream = fs.createWriteStream(target);
+    } catch (e) {
+      rej(e);
+    }
+
     snapshot.export()
-      .pipe(fs.createWriteStream(target))
-      .on('finish', res(target))
+      .pipe(writeStream)
+      .on('finish', () => res(target))
       .on('error', rej);
   });
 
@@ -23,5 +38,36 @@ export function takeHeapSnapshot() {
   }, (e) => {
     snapshot.delete();
     return Promise.reject(e);
+  });
+}
+
+export function startTracing() {
+  const categories = [
+    'blink.console',
+    'devtools.timeline',
+    'toplevel',
+    'disabled-by-default-devtools.timeline',
+    'disabled-by-default-devtools.timeline.frame'
+  ];
+
+  const options = {
+    categoryFilter: categories.join(','),
+    //categoryFilter: '*',
+    traceOptions: 'record-until-full,enable-sampling'
+  };
+
+  return new Promise((res) => {
+    contentTracing.startRecording(options, () => res(true));
+  });
+}
+
+export function stopTracing() {
+  return new Promise((res) => {
+    contentTracing.stopRecording('', (file) => {
+      const target = getTargetFilename('timeline');
+
+      fs.renameSync(file, target);
+      res(target);
+    });
   });
 }

--- a/src/slack-app.tsx
+++ b/src/slack-app.tsx
@@ -83,7 +83,13 @@ export class SlackApp extends SimpleView<SlackAppModel> {
 
   async takeHeapshot() {
     await this.viewModel.toggleDrawer.execute().toPromise();
-    await this.viewModel.store.channels.filter(x => x && x.length > 0).take(1).toPromise();
+    await this.viewModel.store.channels
+      .filter(x => x && x.length > 0)
+      .take(1)
+      .timeout(10 * 1000)
+      .catch(() => Observable.of(true))
+      .toPromise();
+
     await Observable.timer(250).toPromise();
     //await takeHeapSnapshot();
   }

--- a/src/slack-app.tsx
+++ b/src/slack-app.tsx
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as fs from 'fs';
+//import * as path from 'path';
+//import * as fs from 'fs';
 
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
@@ -19,8 +19,9 @@ import { Store } from './lib/store';
 
 import { ChannelListViewModel, ChannelListView } from './channel-list';
 import { MemoryPopover } from './memory-popover';
-import { takeHeapSnapshot } from './profiler';
-import { remote } from 'electron';
+//import { takeHeapSnapshot } from './profiler';
+
+import { createProxyForRemote } from 'electron-remote';
 
 import './lib/standard-operators';
 
@@ -68,26 +69,23 @@ export class SlackAppModel extends Model {
   }
 }
 
-const isDevMode = process.execPath.match(/[\\/]electron/);
-
 export class SlackApp extends SimpleView<SlackAppModel> {
   constructor() {
     super();
     this.viewModel = new SlackAppModel();
     this.viewModel.loadInitialState.execute();
 
-    if (process.env['TRICKLINE_HEAPSHOT_AND_BAIL'] && !isDevMode) {
-      this.takeHeapshot().then(() => remote.app.quit());
+    if (process.env['TRICKLINE_HEAPSHOT_AND_BAIL']) {
+      let mainProcess = createProxyForRemote(null);
+      this.takeHeapshot().then(() => mainProcess.tracingControl.stopTracing(true));
     }
   }
 
   async takeHeapshot() {
     await this.viewModel.toggleDrawer.execute().toPromise();
     await this.viewModel.store.channels.filter(x => x && x.length > 0).take(1).toPromise();
-    await Observable.timer(5 * 1000).toPromise();
-
-    let heapshotFile = await takeHeapSnapshot();
-    fs.renameSync(heapshotFile, path.join(process.cwd(), path.basename(heapshotFile)));
+    await Observable.timer(250).toPromise();
+    //await takeHeapSnapshot();
   }
 
   render() {


### PR DESCRIPTION
This PR adds measurement of startup performance via Chrome Content Tracing as a part of every PR. At the bottom of every build log, you'll see:

```
load [Load]:
  start:                                0.00ms
  end:                                  2890.11ms
  duration:                             2890.11ms
  parseHTML:                            1.52ms
  javaScript:                           817.45ms
  javaScriptCompile:                    0.41ms
  styles:                               6.45ms
  updateLayerTree:                      1.65ms
  layout:                               39.78ms
  paint:                                2.03ms
  raster:                               21.38ms
  composite:                            0.57ms
  extendedInfo:
    domContentLoaded:                   1089.42ms
    loadTime:                           1086.80ms
    firstPaint:                         0.00ms
    javaScript:
```

This info is also saved in the build artifact as `bigrig.json` (`bigrig` is the tool used to generate this analysis).

## TODO:

- [x] Make sure this works in CI
- [ ] Make sure this works in Docker with .env file