### PR TITLE
Maintain selected channel

### DIFF
--- a/src/channel-list-item.tsx
+++ b/src/channel-list-item.tsx
@@ -5,17 +5,18 @@ import { ListItem } from 'material-ui/List';
 import Star from 'material-ui/svg-icons/toggle/star';
 import { grey700, pinkA200, transparent } from 'material-ui/styles/colors';
 
+import { Action } from './lib/action';
+import { ChannelBase } from './lib/models/api-shapes';
+import { ChannelListViewModel } from './channel-list';
+import { fromObservable, Model } from './lib/model';
+import { isDM } from './channel-utils';
 import { SimpleView } from './lib/view';
-import { fromObservable, notify, Model } from './lib/model';
 import { Store } from './lib/store';
 import { Updatable } from './lib/sparse-map';
-import { isDM } from './channel-utils';
 
-import { ChannelBase } from './lib/models/api-shapes';
-
-@notify('isSelected')
 export class ChannelViewModel extends Model {
-  isSelected: boolean;
+  store: Store;
+  selectChannel: Action<void>;
 
   @fromObservable model: ChannelBase;
   @fromObservable id: string;
@@ -25,9 +26,9 @@ export class ChannelViewModel extends Model {
   @fromObservable highlighted: boolean;
   @fromObservable starred: boolean;
 
-  constructor(public readonly store: Store, model: Updatable<ChannelBase>) {
+  constructor(public readonly parent: ChannelListViewModel, model: Updatable<ChannelBase>) {
     super();
-    this.store = store;
+    this.store = parent.store;
 
     model.toProperty(this, 'model');
 
@@ -56,6 +57,10 @@ export class ChannelViewModel extends Model {
     this.when('mentions', 'model.has_unreads',
       (mentions, hasUnreads) => mentions.value > 0 || hasUnreads.value)
       .toProperty(this, 'highlighted');
+
+    this.selectChannel = Action.create(() => {
+      this.parent.selectedChannel = this.model;
+    }, undefined);
   }
 
   private getDisplayName(name: string) {
@@ -104,6 +109,7 @@ export class ChannelListItem extends SimpleView<ChannelViewModel> {
 
     return (
       <ListItem
+        onTouchTap={viewModel.selectChannel.bind()}
         primaryText={viewModel.displayName}
         leftAvatar={leftAvatar}
         rightAvatar={mentionsBadge}

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -3,12 +3,13 @@ import * as React from 'react';
 
 import { ChannelBase } from './lib/models/api-shapes';
 import { CollectionView } from './lib/collection-view';
-import { fromObservable, Model } from './lib/model';
+import { fromObservable, notify, Model } from './lib/model';
 import { Store, ChannelList } from './lib/store';
 
 import { ChannelViewModel, ChannelListItem } from './channel-list-item';
 import { channelSort } from './channel-utils';
 
+@notify('selectedChannel')
 export class ChannelListViewModel extends Model {
   store: Store;
   selectedChannel: ChannelBase;
@@ -34,7 +35,7 @@ export class ChannelListViewModel extends Model {
 export class ChannelListView extends CollectionView<ChannelListViewModel, ChannelViewModel> {
   viewModelFactory(index: number) {
     const channel = this.viewModel.orderedChannels[index];
-    return new ChannelViewModel(this.viewModel.store, channel);
+    return new ChannelViewModel(this.viewModel, channel);
   }
 
   renderItem(viewModel: ChannelViewModel) {

--- a/src/slack-app.tsx
+++ b/src/slack-app.tsx
@@ -51,6 +51,7 @@ export class SlackAppModel extends Model {
   channelList: ChannelListViewModel;
   loadInitialState: Action<void>;
   @fromObservable isOpen: boolean;
+  @fromObservable selectedChannel: any;
 
   constructor() {
     super();
@@ -63,6 +64,10 @@ export class SlackAppModel extends Model {
     this.store = new Store(process.env.SLACK_API_TOKEN || window.localStorage.getItem('token'));
     this.toggleDrawer = Action.create(() => isOpen = !isOpen, false);
     this.channelList = new ChannelListViewModel(this.store);
+
+    this.when('channelList.selectedChannel')
+      .map((c: any) => c.value)
+      .toProperty(this, 'selectedChannel');
 
     this.loadInitialState = new Action<void>(() => this.store.fetchInitialChannelList(), undefined);
     this.toggleDrawer.result.toProperty(this, 'isOpen');
@@ -117,6 +122,8 @@ export class SlackApp extends SimpleView<SlackAppModel> {
           <Drawer open={vm.isOpen} zDepth={1} width={DrawerWidth}>
             {channelListView}
           </Drawer>
+
+          <span>{vm.selectedChannel ? vm.selectedChannel.name : ''}</span>
 
           <MemoryPopover />
         </div>


### PR DESCRIPTION
Each `ChannelViewModel` gets a reference to its parent `ChannelListViewModel`. We'll create an action on the channel that updates its parent's `selectedChannel` property. That property is marked as `@notify`, so that the top-level `SlackApp` can listen to it.

There might be a smarter / cooler way to do this. 🤔 