### PR TITLE
Channel header with members & topic

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -5,5 +5,6 @@ declare module 'electron-devtools-installer';
 declare module 'electron-remote';
 declare module 'dotenv';
 declare module 'lodash.pick';
+declare module 'lru-cache';
 declare module 'material-ui/*';
 declare module 'react-virtualized';

--- a/src/channel-header.tsx
+++ b/src/channel-header.tsx
@@ -1,40 +1,84 @@
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 import AppBar from 'material-ui/AppBar';
+import { Tab } from 'material-ui/Tabs';
 
 import { Action } from './lib/action';
-import { ChannelBase } from './lib/models/api-shapes';
+import { Channel, ChannelBase } from './lib/models/api-shapes';
+import { ChannelListViewModel } from './channel-list';
 import { Model, fromObservable } from './lib/model';
+import { isChannel } from './channel-utils';
 import { SimpleView } from './lib/view';
 import { Store } from './lib/store';
+import { when } from './lib/when';
 
 export class ChannelHeaderViewModel extends Model {
-  toggleDrawer: Action<boolean>;
-  @fromObservable isDrawerOpen: boolean;
   @fromObservable selectedChannel: ChannelBase;
+  @fromObservable channelInfo: Channel;
+  @fromObservable members: Array<string>;
+  @fromObservable topic: string;
+  @fromObservable isDrawerOpen: boolean;
+  toggleDrawer: Action<boolean>;
 
-  constructor(readonly store: Store) {
+  constructor(public readonly store: Store, listViewModel: ChannelListViewModel) {
     super();
 
     let isDrawerOpen = false;
     this.toggleDrawer = Action.create(() => isDrawerOpen = !isDrawerOpen, false);
     this.toggleDrawer.result.toProperty(this, 'isDrawerOpen');
+
+    when(listViewModel, x => x.selectedChannel)
+      .toProperty(this, 'selectedChannel');
+
+    when(this, x => x.selectedChannel)
+      .filter(c => !!c && isChannel(c))
+      .switchMap(c => {
+        this.store.channels.invalidate(c.id);
+        return this.store.channels.listen(c.id);
+      })
+      .map(res => res.channel)
+      .toProperty(this, 'channelInfo');
   }
 }
 
 export class ChannelHeaderView extends SimpleView<ChannelHeaderViewModel> {
-
   render() {
     const channelName = this.viewModel.selectedChannel ?
       this.viewModel.selectedChannel.name :
       'Trickline';
+
+    let tabs = [];
+    if (this.viewModel.channelInfo) {
+      const tabStyle = {
+        paddingLeft: '20px',
+        paddingRight: '20px'
+      };
+
+      tabs.push(
+        <Tab
+          key='members'
+          label={`Members: ${this.viewModel.channelInfo.members.length}`}
+          style={tabStyle}
+        />
+      );
+
+      tabs.push(
+        <Tab
+          key='topic'
+          label={this.viewModel.channelInfo.topic.value}
+          style={tabStyle}
+        />
+      );
+    }
 
     return (
       <AppBar
         title={channelName}
         zDepth={2}
         onLeftIconButtonTouchTap={this.viewModel.toggleDrawer.bind()}
-      />
+      >
+        {tabs}
+      </AppBar>
     );
   }
 }

--- a/src/channel-utils.ts
+++ b/src/channel-utils.ts
@@ -13,6 +13,10 @@ export function channelSort(
   return a.name.localeCompare(b.name);
 }
 
+export function isChannel(channel: ChannelBase): boolean {
+  return !!channel.id && channel.id[0] === 'C';
+}
+
 export function isDM(channel: ChannelBase): boolean {
   return !!channel.id && channel.id[0] === 'D';
 }

--- a/src/lib/models/api-call.ts
+++ b/src/lib/models/api-call.ts
@@ -1,7 +1,7 @@
 import { RecursiveProxyHandler } from 'electron-remote';
 import { Observable } from 'rxjs/Observable';
 
-import { User } from './api-shapes';
+import { User, Channel } from './api-shapes';
 
 import '../standard-operators';
 import 'rxjs/add/observable/dom/ajax';
@@ -13,6 +13,10 @@ export interface ApiCall {
 
 export interface UserResponse extends ApiCall {
   user: User;
+}
+
+export interface ChannelResponse extends ApiCall {
+  channel: Channel;
 }
 
 export function createApi(token?: string): any {

--- a/src/lib/models/api-shapes.ts
+++ b/src/lib/models/api-shapes.ts
@@ -40,6 +40,7 @@ export interface Channel extends ChannelBase {
   is_general: boolean;
   is_archived: boolean;
   is_open: boolean;
+  members: Array<string>;
   topic: { value: string, creator: string, last_set: string };
   purpose: { value: string, creator: string, last_set: string };
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { InMemorySparseMap, SparseMap } from './sparse-map';
 import { Updatable } from './updatable';
-import { createApi, UserResponse } from './models/api-call';
+import { createApi, ChannelResponse, UserResponse } from './models/api-call';
 import { Channel, ChannelBase, Group, DirectMessage, UsersCounts } from './models/api-shapes';
 
 import './standard-operators';
@@ -11,13 +11,15 @@ export type ChannelList = Array<Updatable<ChannelBase>>;
 
 export class Store {
   api: any;
-  channels: SparseMap<string, ChannelBase>;
+  channels: SparseMap<string, ChannelResponse>;
   users: SparseMap<string, UserResponse>;
   joinedChannels: Updatable<ChannelList>;
 
   constructor(token?: string) {
     this.api = createApi(token);
-    this.channels = new InMemorySparseMap<string, ChannelBase>();
+    this.channels = new InMemorySparseMap<string, ChannelBase>((channel) => {
+      return this.api.channels.info({ channel });
+    });
     this.users = new InMemorySparseMap<string, UserResponse>((user) => {
       return this.api.users.info({ user });
     });

--- a/src/slack-app.tsx
+++ b/src/slack-app.tsx
@@ -57,10 +57,7 @@ export class SlackAppModel extends Model {
 
     this.store = new Store(process.env.SLACK_API_TOKEN || window.localStorage.getItem('token'));
     this.channelList = new ChannelListViewModel(this.store);
-    this.channelHeader = new ChannelHeaderViewModel(this.store);
-
-    when(this, x => x.channelList.selectedChannel)
-      .toProperty(this.channelHeader, 'selectedChannel');
+    this.channelHeader = new ChannelHeaderViewModel(this.store, this.channelList);
 
     when(this, x => x.channelHeader.isDrawerOpen)
       .toProperty(this, 'isDrawerOpen');


### PR DESCRIPTION
Adds some more info to the `AppBar` from a `channels.info` call:

![](https://d3vv6lp55qjaqc.cloudfront.net/items/0D2U0W0Q0u0V3H3g2l1P/Screen%20Recording%202017-02-28%20at%2008.56%20PM.gif?X-CloudApp-Visitor-Id=1741631&v=6413e7aa)

There are a few issues with this right now:

1. In `store.fetchInitialChannelList`, we call `setDirect` on an individual channel with the result from `users.counts`. The problem is if you try to `listen` to that `Updatable`, you'll only ever get the small `users.counts` result. So in its current state we have to `invalidate` the current result to make it use its factory method.
1. Shuffling properties from one VM to another will cause issues if you try to use that property in the destination view-model. `when` throws on properties that don't yet exist. We're working around it by passing the view-model that has the info (in this case, the `ChannelList`) into the one that doesn't (the `ChannelHeader`).