### PR TITLE
Update channel unreads via RTM

### DIFF
--- a/src/channel-header.tsx
+++ b/src/channel-header.tsx
@@ -36,9 +36,9 @@ export class ChannelHeaderViewModel extends Model {
       .toProperty(this, 'channelInfo');
 
     // NB: This works but it's too damn clever
-    when(this, x => x.channelInfo)
+    this.innerDisp.add(when(this, x => x.channelInfo)
       .filter(x => x && !x.topic)
-      .subscribe(x => this.store.channels.listen(x.id, x.api).invalidate())
+      .subscribe(x => this.store.channels.listen(x.id, x.api).invalidate()));
 
     when(this, x => x.channelInfo.members)
       .startWith([])

--- a/src/lib/models/api-shapes.ts
+++ b/src/lib/models/api-shapes.ts
@@ -91,7 +91,7 @@ export interface Message {
 
   ephemeral_msg_type: number; // based on EphemeralMsgType.id
 
-  user?: string; // nullable userId
+  user?: string | User; // nullable userId
   username: string;
   topic: string;
   purpose: string;

--- a/src/lib/sparse-map.ts
+++ b/src/lib/sparse-map.ts
@@ -96,6 +96,7 @@ class InMemorySparseMap<K, V> implements SparseMap<K, V> {
   invalidate(key: K): Promise<void> {
     let val = this._latest.get(key);
     if (val) {
+      // Release whatever subscription val's playOnto is holding currently
       val.playOnto(Observable.empty());
       this._latest.delete(key);
     }

--- a/src/lib/sparse-map.ts
+++ b/src/lib/sparse-map.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs/Observable';
-import { Updatable } from './updatable';
+import { Updatable, MergeStrategy } from './updatable';
 
 import './standard-operators';
 
@@ -48,10 +48,12 @@ export class SparseMapMixins {
 class InMemorySparseMap<K, V> implements SparseMap<K, V> {
   private _latest: Map<K, Updatable<V>>;
   private _factory: ((key: K, hint?: any) => Observable<V>) | undefined;
+  private _strategy: MergeStrategy;
 
-  constructor(factory: ((key: K, hint?: any) => Observable<V>) | undefined = undefined) {
+  constructor(factory: ((key: K, hint?: any) => Observable<V>) | undefined = undefined, strategy: MergeStrategy = 'overwrite') {
     this._latest = new Map();
     this._factory = factory;
+    this._strategy = strategy;
   }
 
   listen(key: K, hint?: any): Updatable<V> {
@@ -60,9 +62,9 @@ class InMemorySparseMap<K, V> implements SparseMap<K, V> {
 
     if (this._factory) {
       let fact = this._factory.bind(this);
-      ret = new Updatable<V>(() => fact(key, hint));
+      ret = new Updatable<V>(() => fact(key, hint), this._strategy);
     } else {
-      ret = new Updatable<V>();
+      ret = new Updatable<V>(undefined, this._strategy);
     }
 
     this._latest.set(key, ret);

--- a/src/lib/standard-operators.ts
+++ b/src/lib/standard-operators.ts
@@ -18,3 +18,4 @@ import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/switch';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/takeUntil';
+import 'rxjs/add/operator/throttleTime';

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -68,7 +68,8 @@ export class Updatable<T> extends Subject<T> {
 
   nextMerge(value: T): void {
     this._hasPendingValue = true;
-    super.next(this._value = Object.assign({}, value || {}, this._value || {}));
+    this._value = Object.assign(this._value || {}, value || {});
+    super.next(this._value);
   }
 
   invalidate() {

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -23,7 +23,7 @@ export class Updatable<T> extends Subject<T> {
     this._factory = factory ? factory : () => Observable.empty();
     this._playOnto = new SerialSubscription();
 
-    switch(strategy || 'overwrite') {
+    switch (strategy || 'overwrite') {
     case 'overwrite':
       this.next = this.nextOverwrite;
       break;

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -74,7 +74,7 @@ export class Updatable<T> extends Subject<T> {
 
   invalidate() {
     this._hasPendingValue = false;
-    this._playOnto.set(Subscription.EMPTY);
+    this.playOnto(this._factory());
   }
 
   playOnto(source: Observable<T>) {

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -74,6 +74,7 @@ export class Updatable<T> extends Subject<T> {
 
   invalidate() {
     this._hasPendingValue = false;
+    this._value = undefined;
     this.playOnto(this._factory());
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,4 +5,3 @@ export function isObject(o: any): boolean {
 export function isFunction(o: any): boolean {
   return !!(o && o.constructor && o.call && o.apply);
 };
-

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,8 @@
+export function isObject(o: any): boolean {
+  return o === Object(o);
+}
+
+export function isFunction(o: any): boolean {
+  return !!(o && o.constructor && o.call && o.apply);
+};
+

--- a/src/lib/when.ts
+++ b/src/lib/when.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 import { ChangeNotification, Model, TypedChangeNotification } from './model';
+import { isFunction, isObject } from './utils';
 
 import * as LRU from 'lru-cache';
 import { Updatable } from './updatable';
@@ -7,14 +8,6 @@ import { Updatable } from './updatable';
 const proxyCache = LRU(64);
 
 import './standard-operators';
-
-function isObject(o: any): boolean {
-  return o === Object(o);
-}
-
-function isFunction(o: any): boolean {
-  return !!(o && o.constructor && o.call && o.apply);
-};
 
 const identifier = /^[$A-Z_][0-9A-Z_$]*$/i;
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -26,14 +26,14 @@ export class Store {
 
     this.channels = new InMemorySparseMap<string, ChannelBase>((channel, api: Api) => {
       return this.infoApiForModel(channel, api)();
-    });
+    }, 'merge');
 
     this.users = new InMemorySparseMap<string, User>((user, api: Api) => {
       return api.users.info({ user }).map(({ user }: { user: User }) => {
         user.api = api;
         return user;
       });
-    });
+    }, 'merge');
 
     this.joinedChannels = new Updatable<ChannelList>(() => Observable.of([]));
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,7 +9,7 @@ import { asyncMap } from './lib/promise-extras';
 import { isChannel, isGroup, isDM } from './channel-utils';
 
 import './lib/standard-operators';
-import 'rxjs/Observable/dom/webSocket';
+import 'rxjs/add/observable/dom/webSocket';
 
 export type ChannelList = Array<Updatable<ChannelBase|null>>;
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,7 +39,7 @@ export class Store {
 
     this.events = new InMemorySparseMap<EventType, Message>();
     this.events.listen('user_change')
-      .subscribe(({user}) => this.users.listen(user.id).playOnto(Observable.of(user)));
+      .subscribe(msg => this.users.listen(msg.user.id, msg.api).playOnto(Observable.of(msg.user)));
 
     // NB: This is the lulzy way to update channel counts when marks
     // change, but we should definitely remove this code later
@@ -97,7 +97,7 @@ export class Store {
   private makeUpdatableForModel(model: ChannelBase & Api, api: Api) {
     model.api = api;
 
-    const updater = this.channels.listen(model.id);
+    const updater = this.channels.listen(model.id, api);
     updater.playOnto(Observable.of(model));
     return updater;
   }

--- a/test/lib/sparse-map-spec.ts
+++ b/test/lib/sparse-map-spec.ts
@@ -1,0 +1,37 @@
+import { Observable } from 'rxjs/Observable';
+
+import { MergeStrategy } from '../../src/lib/updatable';
+import { InMemorySparseMap, SparseMap } from '../../src/lib/sparse-map';
+import { TestClass, expect } from '../support';
+
+export type ValueFactoryFunction =
+  ((key: string, hint?: any) => Observable<Object>);
+export type CreateFixtureFunction =
+  ((factory: ValueFactoryFunction, strategy: MergeStrategy) => SparseMap<string, Object>);
+
+function testsForClass(Klass: Function, createFixture: CreateFixtureFunction) {
+  const name = Klass.name;
+
+  describe(`The ${name} class interface implementation`, function() {
+    it ('smoke tests successfully', function() {
+      let fixture = createFixture(() => Observable.of(new TestClass()), 'overwrite');
+
+      let result = fixture.listen('foo');
+      expect((result.value as TestClass).derived).to.equal(42);
+    });
+
+    it ('creates Updatables with Merge Strategy semantics', function() {
+      let fixture = createFixture(() => Observable.of({a: 1}), 'merge');
+
+      let result = fixture.listen('foo');
+      expect(result.value).to.deep.equal({a: 1});
+
+      result.next({b: 2});
+      expect(result.value).to.deep.equal({a: 1, b: 2});
+    });
+  });
+}
+
+testsForClass(InMemorySparseMap, (factory, strategy) => {
+  return new InMemorySparseMap(factory, strategy);
+});

--- a/test/lib/updatable-spec.ts
+++ b/test/lib/updatable-spec.ts
@@ -105,4 +105,29 @@ describe('The Updatable class', function() {
     fixture.subscribe(x => latest = x);
     expect(latest).to.equal(42);
   });
+
+  it('shallow merges objects when used with the merge strategy', function() {
+    let fixture = new Updatable<Object>(() => Observable.of({a: 1}), 'merge');
+    expect(fixture.value).to.deep.equal({a: 1});
+
+    fixture.next({b: 2});
+    expect(fixture.value).to.deep.equal({a: 1, b: 2});
+
+    fixture.next({a: 5});
+    expect(fixture.value).to.deep.equal({a: 5, b: 2});
+  });
+
+  it('drops the current value on invalidate', function() {
+    let fixture = new Updatable<Object>(() => Observable.of({a: 1}), 'merge');
+    expect(fixture.value).to.deep.equal({a: 1});
+
+    fixture.next({b: 2});
+    expect(fixture.value).to.deep.equal({a: 1, b: 2});
+
+    fixture.next({a: 5});
+    expect(fixture.value).to.deep.equal({a: 5, b: 2});
+
+    fixture.invalidate();
+    expect(fixture.value).to.deep.equal({a: 1});
+  });
 });


### PR DESCRIPTION
This PR updates channel unread counts when RTM tells us that a marker changes. Note that we're not doing this the efficient way, we're doing it the slop way via polling `users.counts`. It's good for the demo though!

To do this, both `Updatable` and `SparseMap` now get a new "strategy" parameter. When set to "merge", the previous value and the current value get smushed together via `Object.assign`. Why? Consider the following:

1. We call `users.counts`, we get a partial Channel object
1. We call `channel.info` to get a real Channel object, cool we've got topics and shit
1. We call `users.counts` again hwhoops no more topic

## TODO:

- [x] More Updatable tests
- [x] Write SparseMap tests