### PR TITLE
Improve debuggability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A fast, offline Slack client",
   "main": "src/main.ts",
   "scripts": {
-    "start": "cross-env DEBUG='*,-babel,-electron-compile,-trickline-noisy' electron-forge start",
+    "start": "cross-env DEBUG='trickline' electron-forge start",
     "clean-build": "ts-node -D ./docker/surf-build-current",
     "test-renderer": "xvfb-maybe electron-mocha --renderer --watch-extensions tsx,ts \"./test/**/*.{js,ts}\"",
     "dtest": "electron-mocha --renderer --interactive --watch-extensions tsx,ts \"./test/**/*.{js,ts}\"",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A fast, offline Slack client",
   "main": "src/main.ts",
   "scripts": {
-    "start": "electron-forge start",
+    "start": "cross-env DEBUG='*,-babel,-electron-compile,-trickline-noisy' electron-forge start",
     "clean-build": "ts-node -D ./docker/surf-build-current",
     "test-renderer": "xvfb-maybe electron-mocha --renderer --watch-extensions tsx,ts \"./test/**/*.{js,ts}\"",
     "dtest": "electron-mocha --renderer --interactive --watch-extensions tsx,ts \"./test/**/*.{js,ts}\"",
@@ -59,7 +59,7 @@
     "bigrig": "1.3.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "cross-env": "^3.1.4",
+    "cross-env": "3.1.4",
     "csslint": "^1.0.5",
     "electron-compilers": "^5.5.1",
     "electron-mocha": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/electron": "^1.4.31",
     "@types/lru-cache": "4.0.0",
     "@types/react": "^15.0.4",
-    "debug": "^2.6.0",
+    "debug": "2.3.2",
     "dotenv": "^4.0.0",
     "electron-compile": "^6.1.2",
     "electron-debug": "^1.1.0",

--- a/src/channel-header.tsx
+++ b/src/channel-header.tsx
@@ -38,7 +38,7 @@ export class ChannelHeaderViewModel extends Model {
     // NB: This works but it's too damn clever
     this.innerDisp.add(when(this, x => x.channelInfo)
       .filter(x => x && !x.topic)
-      .subscribe(x => this.store.channels.listen(x.id, x.api).invalidate()));
+      .subscribe(x => this.store.updateChannelToLatest(x.id, x.api));
 
     when(this, x => x.channelInfo.members)
       .startWith([])

--- a/src/lib/custom-operators.ts
+++ b/src/lib/custom-operators.ts
@@ -7,10 +7,21 @@ export function createCollection<T>(this: Observable<T>): Array<T> {
   return ret;
 }
 
+export function breakOn<T>(this: Observable<T>, selector: ((x: T) => boolean)): Observable<T> {
+  return this.lift({
+    call: (sub, src) => src.subscribe((x: T) => {
+      if (selector(x)) debugger;
+      sub.next(x);
+    }, sub.error.bind(sub), sub.complete.bind(sub))
+  });
+}
+
 Observable.prototype['createCollection'] = createCollection;
+Observable.prototype['breakOn'] = breakOn;
 
 declare module 'rxjs/Observable' {
   interface Observable<T> {
     createCollection: typeof createCollection;
+    breakOn: typeof breakOn;
   }
 }

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -85,7 +85,10 @@ export function fromObservable(target: Model, propertyKey: string): void {
             this.changing.next({sender: target, property: propertyKey, value: this[valPropertyKey]});
             this[valPropertyKey] = x;
             this.changed.next({sender: target, property: propertyKey, value: this[valPropertyKey]});
-          }, (e) => { setTimeout(() => { throw e; }, 10) }, () => {
+          }, (e) => {
+            d(`ToProperty on key ${propertyKey} failed! Last value was ${JSON.stringify(this[valPropertyKey])}`);
+            setTimeout(() => { throw e; }, 10);
+          }, () => {
             d(`Observable for ${propertyKey} completed!`);
           }));
 

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -85,7 +85,7 @@ export function fromObservable(target: Model, propertyKey: string): void {
             this.changing.next({sender: target, property: propertyKey, value: this[valPropertyKey]});
             this[valPropertyKey] = x;
             this.changed.next({sender: target, property: propertyKey, value: this[valPropertyKey]});
-          }, (e) => { throw e; }, () => {
+          }, (e) => { setTimeout(() => { throw e; }, 10) }, () => {
             d(`Observable for ${propertyKey} completed!`);
           }));
 

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription, ISubscription } from 'rxjs/Subscription';
 import { SerialSubscription } from './serial-subscription';
+import * as debug from 'debug';
 
 import { Subject } from 'rxjs/Subject';
 
@@ -9,6 +10,8 @@ import './standard-operators';
 
 export type Pair<K, V> = { Key: K, Value: V };
 export type MergeStrategy = 'overwrite' | 'merge';
+
+const d = debug('trickline:updatable');
 
 export class Updatable<T> extends Subject<T> {
   private _value: T;
@@ -70,6 +73,11 @@ export class Updatable<T> extends Subject<T> {
     this._hasPendingValue = true;
     this._value = Object.assign(this._value || {}, value || {});
     super.next(this._value);
+  }
+
+  error(error: any) {
+    d(`Updatable threw error: ${error.message}\nCurrent value is ${JSON.stringify(this._value)}\n${error.stack}`);
+    super.error(error);
   }
 
   invalidate() {

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -4,6 +4,8 @@ import { Subscription, ISubscription } from 'rxjs/Subscription';
 import { SerialSubscription } from './serial-subscription';
 import * as debug from 'debug';
 
+import { captureStack } from './utils';
+
 import { Subject } from 'rxjs/Subject';
 
 import './standard-operators';
@@ -70,6 +72,12 @@ export class Updatable<T> extends Subject<T> {
   }
 
   nextMerge(value: T): void {
+    if (value === undefined) {
+      captureStack();
+      d(`Updatable with merge strategy received undefined, this is probably a bug\n${captureStack()}`);
+      return;
+    }
+
     this._hasPendingValue = true;
     this._value = Object.assign(this._value || {}, value || {});
     super.next(this._value);
@@ -82,7 +90,7 @@ export class Updatable<T> extends Subject<T> {
 
   invalidate() {
     this._hasPendingValue = false;
-    this._value = undefined;
+    delete this._value;
     this.playOnto(this._factory());
   }
 

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -79,7 +79,13 @@ export class Updatable<T> extends Subject<T> {
     }
 
     this._hasPendingValue = true;
-    this._value = Object.assign(this._value || {}, value || {});
+
+    if (this._value) {
+      this._value = Object.assign(this._value || {}, value || {});
+    } else {
+      this._value = value;
+    }
+
     super.next(this._value);
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,3 +5,7 @@ export function isObject(o: any): boolean {
 export function isFunction(o: any): boolean {
   return !!(o && o.constructor && o.call && o.apply);
 };
+
+export function captureStack() {
+  try { throw new Error(); } catch (e) { return e.stack; }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -76,6 +76,10 @@ export class Store {
     this.joinedChannels.next(allJoinedChannels);
   }
 
+  updateChannelToLatest(id: string, api: Api) {
+    this.channels.listen(id).playOnto(this.infoApiForModel(id, api)());
+  }
+
   private async fetchSingleInitialChannelList(api: Api): Promise<ChannelList> {
     const joinedChannels: ChannelList = [];
 


### PR DESCRIPTION
This PR fixes a few things around our library to make it way easier to figure out what's going wrong when your code doesn't work:

* Exceptions that `toProperty` receives now show up in console and don't get eaten
* Make terminating an Updatable with Error a noisy operation
* Many classes are now annotated with `debug` so you'll see more information about what's going on
* Fix a bug in Updatable that would cause it to turn null objects into `{}`
* Add a new `breakOn` operator which is super useful for debugging:

```js
myCoolObservable
  .breakOn(x => x === null)  // Now when DevTools is open, getting `null` will break into the debugger
  .subscribe(/*...*/);
```