### PR TITLE
Clicking a DM should clear the topic & members tabs

### DIFF
--- a/src/channel-header.tsx
+++ b/src/channel-header.tsx
@@ -6,16 +6,18 @@ import { Tab } from 'material-ui/Tabs';
 import { Action } from './lib/action';
 import { Channel, ChannelBase } from './lib/models/api-shapes';
 import { ChannelListViewModel } from './channel-list';
+import { isDM } from './channel-utils';
 import { Model, fromObservable } from './lib/model';
 import { SimpleView } from './lib/view';
 import { Store } from './store';
 import { when } from './lib/when';
+import { Observable } from 'rxjs/Observable';
 
 export class ChannelHeaderViewModel extends Model {
   @fromObservable selectedChannel: ChannelBase;
   @fromObservable channelInfo: Channel;
   @fromObservable members: Array<string>;
-  @fromObservable topic: { value: string};
+  @fromObservable topic: { value: string };
   @fromObservable isDrawerOpen: boolean;
   toggleDrawer: Action<boolean>;
 
@@ -31,21 +33,20 @@ export class ChannelHeaderViewModel extends Model {
 
     when(this, x => x.selectedChannel)
       .filter(c => !!c)
-      .switchMap(c => this.store.channels.listen(c.id, c.api))
-      .do(x => console.log(`New ChannelInfo! ${JSON.stringify(x)}`))
+      .flatMap(c => isDM(c) ? Observable.of(null) : this.store.channels.listen(c.id, c.api))
       .toProperty(this, 'channelInfo');
 
     // NB: This works but it's too damn clever
     this.innerDisp.add(when(this, x => x.channelInfo)
-      .filter(x => x && !x.topic)
-      .subscribe(x => this.store.updateChannelToLatest(x.id, x.api));
+      .filter(x => !!x)
+      .subscribe(x => this.store.updateChannelToLatest(x.id, x.api)));
 
     when(this, x => x.channelInfo.members)
       .startWith([])
       .toProperty(this, 'members');
 
     when(this, x => x.channelInfo.topic)
-      .startWith({value: ''})
+      .startWith({ value: '' })
       .toProperty(this, 'topic');
   }
 }


### PR DESCRIPTION
Mini-bug fix: when you move to a DM right now, you don't get a `channelInfo` update. What we instead want is to `null` out `channelInfo` so that we stop rendering `members` and `topic`. 