### PR TITLE
Queue view updates

### DIFF
--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -174,7 +174,7 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
       View.isInFocusSub = Observable.merge(
         Observable.fromEvent(window, 'blur').map(() => false),
         Observable.fromEvent(window, 'focus').map(() => true),
-      ).subscribe(x => {
+      ).startWith(true).subscribe(x => {
         View.isInFocus = x;
 
         // NB: If the window loses focus, then comes back, there could

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 import { AsyncSubject } from 'rxjs/AsyncSubject';
+import { Subscription } from 'rxjs/Subscription';
 import { Subject } from 'rxjs/Subject';
 import { asap } from 'rxjs/scheduler/asap';
 
@@ -99,7 +100,7 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
       .flatMap(() => this.viewModel.changed)
       .takeUntil(this.lifecycle.willUnmount)
       .observeOn(asap)
-      .subscribe(() => { if (this.viewModel) { this.forceUpdate(); } });
+      .subscribe(() => { if (this.viewModel) { this.queueUpdate(); } });
 
     this.lifecycle.willUnmount.subscribe(() => { if (this.viewModel) this.viewModel.unsubscribe(); this.viewModel = null; });
   }
@@ -135,6 +136,51 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
     if (!this.lifecycle.willUnmountSubj) return;
     this.lifecycle.willUnmountSubj.next(true);
     this.lifecycle.willUnmountSubj.complete();
+  }
+
+  static toUpdate: View<any, any>[];
+  static currentRafToken: number;
+  static isInFocus: boolean;
+  static isInFocusSub: Subscription;
+
+  static dispatchUpdates() {
+    const ourViews = View.toUpdate;
+    View.toUpdate = [];
+
+    View.currentRafToken = 0;
+    ourViews.forEach(x => {
+      if (!x.viewModel) return;
+      x.forceUpdate();
+    });
+  }
+
+  private queueUpdate() {
+    View.toUpdate = View.toUpdate || [];
+    View.toUpdate.push(this);
+
+    if (!View.isInFocusSub) {
+      View.isInFocusSub = Observable.merge(
+        Observable.fromEvent(window, 'blur').map(() => false),
+        Observable.fromEvent(window, 'focus').map(() => true),
+      ).subscribe(x => {
+        View.isInFocus = x;
+
+        // NB: If the window loses focus, then comes back, there could
+        // be an up-to-250ms delay between the window regaining focus
+        // and the idle setTimeout actually running. That's bad, we will
+        // instead cancel our lazy timer and fire a quick one
+        if (x && View.currentRafToken) {
+          clearTimeout(View.currentRafToken);
+          this.queueUpdate();
+        }
+      });
+    }
+
+    if (View.currentRafToken === 0 || View.currentRafToken === undefined) {
+      View.currentRafToken = View.isInFocus ?
+        requestAnimationFrame(View.dispatchUpdates) :
+        window.setTimeout(View.dispatchUpdates, 250);
+    }
   }
 }
 

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -166,7 +166,7 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
         View.isInFocus = x;
 
         // NB: If the window loses focus, then comes back, there could
-        // be an up-to-250ms delay between the window regaining focus
+        // be an up-to-750ms delay between the window regaining focus
         // and the idle setTimeout actually running. That's bad, we will
         // instead cancel our lazy timer and fire a quick one
         if (x && View.currentRafToken) {
@@ -179,7 +179,7 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
     if (View.currentRafToken === 0 || View.currentRafToken === undefined) {
       View.currentRafToken = View.isInFocus ?
         requestAnimationFrame(View.dispatchUpdates) :
-        window.setTimeout(View.dispatchUpdates, 250);
+        window.setTimeout(View.dispatchUpdates, 750);
     }
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,7 +37,7 @@ function deferredPut<T, Key>(this: Dexie.Table<T, Key>, item: T): Promise<void> 
   let newItem = { item, completion: new AsyncSubject<void>() };
 
   let createIdle = () => window.requestIdleCallback(deadline => {
-    while (deadline.timeRemaining() > 5) {
+    while (deadline.timeRemaining() > 5/*ms*/) {
       let itemsToAdd = this.deferredItems;
       this.deferredItems = itemsToAdd.splice(128);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,7 +37,7 @@ function deferredPut<T, Key>(this: Dexie.Table<T, Key>, item: T): Promise<void> 
   let newItem = { item, completion: new AsyncSubject<void>() };
 
   let createIdle = () => window.requestIdleCallback(deadline => {
-    while (deadline.timeRemaining() > 0) {
+    while (deadline.timeRemaining() > 5) {
       let itemsToAdd = this.deferredItems;
       this.deferredItems = itemsToAdd.splice(128);
 


### PR DESCRIPTION
This PR makes sure we're not calling `forceUpdate` in weird places and also ensures we call it all at once. We also defer calling `forceUpdate` when the window isn't in focus. 

With this change, in production mode we're pretty consistently hitting 60FPS as long as we don't end up having to fetch user information :tada: 🎈 