### PR TITLE
Updatable Arrays and Collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lru-cache": "^4.0.2",
     "material-ui": "^0.16.7",
     "moment": "2.17.1",
+    "observe-js": "0.5.7",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-hot-loader": "^3.0.0-beta.6",
@@ -54,6 +55,7 @@
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/mocha": "^2.2.35",
+    "@types/observe-js": "0.5.28",
     "babel-cli": "^6.18.0",
     "babel-eslint": "^7.1.1",
     "babel-plugin-transform-async-to-generator": "^6.16.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "electron-remote": "1.1.2",
     "keycode": "^2.1.8",
     "lodash-es": "4.17.4",
+    "lodash.isequal": "4.5.0",
     "lodash.isfunction": "3.0.8",
     "lodash.isobject": "3.0.2",
     "lodash.pick": "4.4.0",

--- a/src/channel-header.tsx
+++ b/src/channel-header.tsx
@@ -122,6 +122,7 @@ export class ChannelHeaderView extends SimpleView<ChannelHeaderViewModel> {
         <ChannelMembersView
           key={this.viewModel.channelInfo.name}
           viewModel={this.viewModel.channelMembers}
+          arrayProperty='members'
           width={300}
           height={300}
         />

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -31,16 +31,12 @@ export class ChannelListViewModel extends Model {
 }
 
 export class ChannelListView extends CollectionView<ChannelListViewModel, ChannelViewModel> {
-  viewModelFactory(index: number) {
+  viewModelFactory(_item: any, index: number) {
     const channel = this.viewModel.orderedChannels[index];
     return new ChannelViewModel(this.viewModel, channel);
   }
 
   renderItem(viewModel: ChannelViewModel) {
     return <ChannelListItem viewModel={viewModel} />;
-  }
-
-  rowCount() {
-    return this.viewModel.orderedChannels.length;
   }
 }

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -20,8 +20,6 @@ export class ChannelListViewModel extends Model {
     super();
 
     store.joinedChannels.toProperty(this, 'channels');
-    this.changed.subscribe((v) => console.log(v.property));
-
     when(this, x => x.channels)
       .map(list => {
         let ret = Array.from(store.channels.listenMany(list || []).values());

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -20,6 +20,7 @@ export class ChannelListViewModel extends Model {
     super();
 
     store.joinedChannels.toProperty(this, 'channels');
+    this.changed.subscribe((v) => console.log(v.property));
 
     when(this, x => x.channels)
       .map(list => {

--- a/src/channel-members-view.tsx
+++ b/src/channel-members-view.tsx
@@ -18,7 +18,7 @@ export class ChannelMembersViewModel extends Model {
 }
 
 export class ChannelMembersView extends CollectionView<ChannelMembersViewModel, UserViewModel> {
-  viewModelFactory(index: number) {
+  viewModelFactory(_item: any, index: number) {
     return new UserViewModel(
       this.viewModel.store,
       this.viewModel.members[index],
@@ -28,9 +28,5 @@ export class ChannelMembersView extends CollectionView<ChannelMembersViewModel, 
 
   renderItem(viewModel: UserViewModel) {
     return <UserListItem viewModel={viewModel} />;
-  }
-
-  rowCount() {
-    return this.viewModel.members.length;
   }
 }

--- a/src/lib/collection-view.tsx
+++ b/src/lib/collection-view.tsx
@@ -22,6 +22,7 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
     extends View<T, CollectionViewProps<T>> {
   private viewModelCache: { [key: number]: TChild } = {};
   private readonly arraySub: SerialSubscription;
+  private listRef: List;
 
   readonly lifecycle: Lifecycle<CollectionViewProps<T>, null>;
 
@@ -53,6 +54,7 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
         const observer = new ArrayObserver(p);
 
         console.log("OPENING AN OBSERVER");
+        if (this.listRef) this.listRef.forceUpdateGrid();
         observer.open((splices) => {
           console.log("NOTIFY OF CHANGE");
           /*
@@ -74,7 +76,7 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
           this.viewModelCache = {};
 
           console.log("FORCING UPDATE");
-          this.forceUpdate();
+          if (this.listRef) this.listRef.forceUpdateGrid();
         });
 
         this.arraySub.set(() => observer.close());
@@ -125,10 +127,12 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
       );
     }
 
+    let refBind = ((l: List) => this.listRef = l).bind(this);
     return (
       <AutoSizer {...autoSizerProps}>
         {({ width, height }: { width: number, height: number }) => (
           <List
+            ref={refBind}
             width={width}
             height={height}
             {...listProps}

--- a/src/lib/collection-view.tsx
+++ b/src/lib/collection-view.tsx
@@ -57,6 +57,7 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
   }
 
   clearViewModelCache() {
+    // TODO: It would be rull cool if we could reuse these in some sane way
     Object.keys(this.viewModelCache).forEach(x => this.viewModelCache[x].unsubscribe());
     this.viewModelCache = {};
   }

--- a/src/lib/collection-view.tsx
+++ b/src/lib/collection-view.tsx
@@ -44,7 +44,11 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
       .takeUntil(this.lifecycle.willUnmount)
       .subscribe(() => {
         this.clearViewModelCache();
-        if (this.listRef) this.listRef.forceUpdateGrid();
+
+        this.queueUpdate(() => {
+          if (!this.viewModel || !this.listRef) return;
+          this.listRef.forceUpdateGrid();
+        });
       }, (e) => setTimeout(() => { throw e; }, 10));
 
     this.lifecycle.willUnmount.subscribe(() => {
@@ -112,4 +116,3 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
       </AutoSizer>
     );
   }
-}

--- a/src/lib/collection-view.tsx
+++ b/src/lib/collection-view.tsx
@@ -120,3 +120,4 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
       </AutoSizer>
     );
   }
+}

--- a/src/lib/collection-view.tsx
+++ b/src/lib/collection-view.tsx
@@ -46,7 +46,10 @@ export abstract class CollectionView<T extends Model, TChild extends Model>
         this.clearViewModelCache();
 
         this.queueUpdate(() => {
-          if (!this.viewModel || !this.listRef) return;
+          if (!this.viewModel) return;
+          this.forceUpdate();
+
+          if (!this.listRef) return;
           this.listRef.forceUpdateGrid();
         });
       }, (e) => setTimeout(() => { throw e; }, 10));

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -1,6 +1,7 @@
 import { Observable } from 'rxjs/Observable';
 import { ISubscription, Subscription } from 'rxjs/Subscription';
 import { Subject } from 'rxjs/Subject';
+import * as isEqual from 'lodash.isequal';
 
 import * as debug from 'debug';
 
@@ -82,6 +83,8 @@ export function fromObservable(target: Model, propertyKey: string): void {
 
         this[subPropertyKey].add(observableForProperty.subscribe(
           (x) => {
+            if (isEqual(this[valPropertyKey], x)) return;
+
             this.changing.next({sender: target, property: propertyKey, value: this[valPropertyKey]});
             this[valPropertyKey] = x;
             this.changed.next({sender: target, property: propertyKey, value: this[valPropertyKey]});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -5,7 +5,6 @@ import { SparseMap, InMemorySparseMap } from './sparse-map';
 import { Api, createApi, infoApiForChannel } from './models/slack-api';
 import { ChannelBase, Message, User, UsersCounts } from './models/api-shapes';
 import { EventType } from './models/event-type';
-import { asyncReduce } from './promise-extras';
 import { ArrayUpdatable } from './updatable';
 
 import 'rxjs/add/observable/dom/webSocket';

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2,7 +2,6 @@ import { Subscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
 
 import { SparseMap, InMemorySparseMap } from './sparse-map';
-import { Updatable } from './updatable';
 import { Api, createApi, infoApiForChannel } from './models/slack-api';
 import { ChannelBase, Message, User, UsersCounts } from './models/api-shapes';
 import { EventType } from './models/event-type';

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -133,7 +133,7 @@ export class ArrayUpdatable<T> extends Updatable<T[]> {
     super.next(this._value = value);
 
     this.arraySub.set(
-      observeArray(value).subscribe(() => this.next(value)));
+      observeArray(value).subscribe(() => this.next(Array.from(value))));
   }
 
   unsubscribe() {

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -87,7 +87,7 @@ export class Updatable<T> extends Subject<T> {
     this._hasPendingValue = true;
 
     if (this._value) {
-      this._value = Object.assign(this._value || {}, value || {});
+      this._value = Object.assign({}, this._value || {}, value || {});
     } else {
       this._value = value;
     }

--- a/src/lib/updatable.ts
+++ b/src/lib/updatable.ts
@@ -130,10 +130,10 @@ export class ArrayUpdatable<T> extends Updatable<T[]> {
 
   nextOverwrite(value: T[]): void {
     this._hasPendingValue = true;
-    super.next(this._value = value);
+    super.next(Array.from(this._value = value));
 
     this.arraySub.set(
-      observeArray(value).subscribe(() => this.next(Array.from(value))));
+      observeArray(value).subscribe(() => super.next(Array.from(value))));
   }
 
   unsubscribe() {

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -144,9 +144,9 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
     this.lifecycle.willUnmountSubj.next(true);
     this.lifecycle.willUnmountSubj.complete();
 
-    this.lifecycle.willReceivePropsSubj.complete();
-    this.lifecycle.willUpdateSubj.complete();
-    this.lifecycle.didUpdateSubj.complete();
+    if (this.lifecycle.willReceivePropsSubj) this.lifecycle.willReceivePropsSubj.complete();
+    if (this.lifecycle.willUpdateSubj) this.lifecycle.willUpdateSubj.complete();
+    if (this.lifecycle.didUpdateSubj) this.lifecycle.didUpdateSubj.complete();
   }
 
   static toUpdate: View<any, any>[];
@@ -177,7 +177,7 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
     }
   }
 
-  private queueUpdate() {
+  protected queueUpdate() {
     View.toUpdate = View.toUpdate || [];
     View.toUpdate.push(this);
 

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -166,7 +166,7 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
     try {
       for (let i = 0; i < ourViews.length; i++) {
         const current = ourViews[i];
-        if (!current.viewModel || current.hasBeenRendered) continue;
+        if (!current.viewModel) continue;
 
         current.forceUpdate();
         current.hasBeenRendered = true;

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -68,7 +68,7 @@ class AttachedReactLifecycle<P, S> extends Lifecycle<P, S> {
     }
 
     const ps = this.willReceivePropsSubj = Subject.create();
-    target['componentWillReceiveProps'] = function(props: P) { ps.next(props); }
+    target['componentWillReceiveProps'] = function(props: P) { ps.next(props); };
   }
 }
 

--- a/src/lib/when.ts
+++ b/src/lib/when.ts
@@ -214,6 +214,17 @@ export function when<TSource, TProp1, TProp2, TProp3, TProp4, TRet>(
     sel: ((p1: TProp1, p2: TProp2, p3: TProp3, p4: TProp4) => TRet)):
   Observable<TRet>;
 
+export function when<TSource, TRet>(
+    target: TSource,
+    prop: string): Observable<TRet>;
+
+export function when<TSource, TProp1, TProp2, TRet>(
+    target: TSource,
+    prop1: string,
+    prop2: string,
+    sel: ((p1: TProp1, p2: TProp2) => TRet)):
+  Observable<TRet>;
+
 export function when(target: any, ...propsAndSelector: Array<string|Function|string[]>): Observable<any> {
   return whenPropertyInternal(target, true, ...propsAndSelector);
 }

--- a/src/lib/when.ts
+++ b/src/lib/when.ts
@@ -5,6 +5,7 @@ import { ArrayObserver, splice } from 'observe-js';
 import { ChangeNotification, Model, TypedChangeNotification } from './model';
 import * as isFunction from 'lodash.isfunction';
 import * as isObject from 'lodash.isobject';
+import * as isEqual from 'lodash.isequal';
 
 import * as LRU from 'lru-cache';
 import { Updatable } from './updatable';
@@ -36,7 +37,7 @@ export function whenPropertyInternal(target: any, valueOnly: boolean, ...propsAn
       observableForPropertyChain(target, p).map(x => x.value) :
       observableForPropertyChain(target, p));
 
-  return Observable.combineLatest(...propWatchers, selector).distinctUntilChanged();
+  return Observable.combineLatest(...propWatchers, selector).distinctUntilChanged((x, y) => isEqual(x, y));
 }
 
 export type ArrayChange<T> = { value: T[], splices: splice[] };
@@ -94,7 +95,7 @@ export function observableForPropertyChain(target: any, chain: (Array<string> | 
   }
 
   if (props.length === 1) {
-    return start.distinctUntilChanged((x, y) => x.value === y.value);
+    return start.distinctUntilChanged((x, y) => isEqual(x.value, y.value));
   }
 
   return start    // target.foo
@@ -107,7 +108,7 @@ export function observableForPropertyChain(target: any, chain: (Array<string> | 
         });
     })
     .switch()
-    .distinctUntilChanged((x, y) => x.value === y.value);
+    .distinctUntilChanged((x, y) => isEqual(x.value, y.value));
 }
 
 export function notificationForProperty(target: any, prop: string, before = false): Observable<ChangeNotification> {

--- a/src/lib/when.ts
+++ b/src/lib/when.ts
@@ -94,7 +94,7 @@ export function observableForPropertyChain(target: any, chain: (Array<string> | 
   }
 
   if (props.length === 1) {
-    return start;//.distinctUntilChanged((x, y) => x.value === y.value);
+    return start.distinctUntilChanged((x, y) => x.value === y.value);
   }
 
   return start    // target.foo

--- a/src/lib/when.ts
+++ b/src/lib/when.ts
@@ -94,7 +94,7 @@ export function observableForPropertyChain(target: any, chain: (Array<string> | 
   }
 
   if (props.length === 1) {
-    return start.distinctUntilChanged((x, y) => x.value === y.value);
+    return start;//.distinctUntilChanged((x, y) => x.value === y.value);
   }
 
   return start    // target.foo

--- a/src/message-list-item.tsx
+++ b/src/message-list-item.tsx
@@ -47,11 +47,15 @@ export class MessageViewModel extends Model {
   @fromObservable text: string;
   @fromObservable formattedTime: string;
 
+  @fromObservable profileImage: string;
+  @fromObservable displayName: string;
+
   constructor(public readonly store: Store, public readonly api: Api, message: Message) {
     super();
 
     Observable.of(message).toProperty(this, 'model');
 
+    // XXX: This is a memory leak! UserViewModel binds to Store but never gets freed
     when(this, x => x.model)
       .map(model => new UserViewModel(this.store, model.user as string, api))
       .toProperty(this, 'user');
@@ -63,6 +67,12 @@ export class MessageViewModel extends Model {
     when(this, x => x.model)
       .map(model => moment(parseFloat(model.ts) * 1000).calendar())
       .toProperty(this, 'formattedTime');
+
+    when(this, x => x.user.profileImage)
+      .toProperty(this, 'profileImage');
+
+    when(this, x => x.user.displayName)
+      .toProperty(this, 'displayName');
   }
 }
 

--- a/src/messages-view.tsx
+++ b/src/messages-view.tsx
@@ -25,7 +25,6 @@ export interface RowRendererArgs {
 export class MessagesViewModel extends Model {
   readonly api: Api;
   @fromObservable messages: Array<Message>;
-  @fromObservable messagesCount: number;
 
   constructor(public readonly store: Store, public readonly channel: ChannelBase) {
     super();
@@ -34,13 +33,9 @@ export class MessagesViewModel extends Model {
     when(this, x => x.channel)
       .filter(channel => channel && isChannel(channel))
       .switchMap(channel => store.messages.listen(channel.id, channel.api))
+      .map(x => x || [])
+      .startWith([])
       .toProperty(this, 'messages');
-
-    when(this, x => x.messages)
-      .filter(messages => !!messages)
-      .map(messages => messages.length)
-      .startWith(0)
-      .toProperty(this, 'messagesCount');
   }
 }
 
@@ -50,11 +45,7 @@ export class MessagesView extends CollectionView<MessagesViewModel, MessageViewM
     minHeight: 43
   });
 
-  rowCount() {
-    return this.viewModel.messagesCount;
-  }
-
-  viewModelFactory(index: number) {
+  viewModelFactory(_item: any, index: number) {
     const message = this.viewModel.messages[index];
     return new MessageViewModel(this.viewModel.store, this.viewModel.api, message);
   }
@@ -90,7 +81,7 @@ export class MessagesView extends CollectionView<MessagesViewModel, MessageViewM
         height={height}
         deferredMeasurementCache={this.cache}
         rowHeight={this.cache.rowHeight}
-        rowCount={this.viewModel.messagesCount}
+        rowCount={this.viewModel.messages.length}
         rowRenderer={this.rowRenderer.bind(this)}
       />
     );

--- a/src/slack-app.tsx
+++ b/src/slack-app.tsx
@@ -116,13 +116,14 @@ export class SlackApp extends SimpleView<SlackAppModel> {
     };
 
     const channelListView = vm.isDrawerOpen ? (
-      <ChannelListView viewModel={vm.channelList} />
+      <ChannelListView viewModel={vm.channelList} arrayProperty='orderedChannels' />
     ) : null;
 
     const messagesView = vm.messagesViewModel ? (
       <MessagesView
         key={vm.messagesViewModel.channel.id}
         viewModel={vm.messagesViewModel}
+        arrayProperty='messages'
       />
     ) : null;
 

--- a/test/lib/updatable-spec.ts
+++ b/test/lib/updatable-spec.ts
@@ -1,8 +1,10 @@
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
-import { Updatable } from '../../src/lib/updatable';
+import { ArrayUpdatable, Updatable } from '../../src/lib/updatable';
 
 import { expect } from '../support';
+
+import '../../src/lib/custom-operators';
 
 describe('The Updatable class', function() {
   it('mostly acts like a BehaviorSubject', function() {
@@ -27,7 +29,7 @@ describe('The Updatable class', function() {
     fixture.subscribe(() => {}, (e) => error = e);
     expect(error).not.to.be.ok;
 
-    input.error(new Error("Die"));
+    input.error(new Error('Die'));
     expect(error).to.be.ok;
 
     error = null;
@@ -41,7 +43,7 @@ describe('The Updatable class', function() {
     fixture.subscribe(() => {}, (e) => error = e);
     expect(error).not.to.be.ok;
 
-    fixture.error(new Error("Die"));
+    fixture.error(new Error('Die'));
     expect(error).to.be.ok;
   });
 
@@ -101,5 +103,126 @@ describe('The Updatable class', function() {
 
     fixture.invalidate();
     expect(fixture.value).to.deep.equal({a: 1});
+  });
+});
+
+describe('the ArrayUpdatable class', function() {
+  it('mostly acts like a BehaviorSubject', function() {
+    let fixture = new ArrayUpdatable(() => Observable.of([42]));
+    expect(fixture.value).to.deep.equal([42]);
+
+    let result;
+    fixture.subscribe(x => result = x);
+    expect(result).to.deep.equal([42]);
+
+    fixture = new ArrayUpdatable(() => Observable.of([42]));
+    result = -1;
+    fixture.subscribe(x => result = x);
+    expect(result).to.deep.equal([42]);
+  });
+
+  it('blows up when we trash it', function() {
+    let input = new Subject<number[]>();
+    let fixture = new ArrayUpdatable<number>(() => input);
+
+    let error = null;
+    fixture.subscribe(() => {}, (e) => error = e);
+    expect(error).not.to.be.ok;
+
+    input.error(new Error('Die'));
+    expect(error).to.be.ok;
+
+    error = null;
+    fixture.subscribe(() => {}, (e) => error = e);
+    expect(error).to.be.ok;
+
+    input = new Subject();
+    fixture = new ArrayUpdatable(() => input);
+
+    error = null;
+    fixture.subscribe(() => {}, (e) => error = e);
+    expect(error).not.to.be.ok;
+
+    fixture.error(new Error('Die'));
+    expect(error).to.be.ok;
+  });
+
+  it('calls the factory input but replays it', function() {
+    let input = new Subject<number[]>();
+    let fixture = new ArrayUpdatable<number>(() => input);
+
+    let value = [-1];
+    let sub = fixture.subscribe(x => value = x);
+
+    expect(value).to.deep.equal([-1]);
+
+    input.next([42]);
+    input.complete();
+    sub.unsubscribe();
+    expect(value).to.deep.equal([42]);
+
+    value = [-1];
+    fixture.subscribe(x => value = x).unsubscribe();
+    expect(value).to.deep.equal([42]);
+
+    value = [-1];
+    fixture.subscribe(x => value = x);
+    fixture.next([50]);
+    expect(value).to.deep.equal([50]);
+  });
+
+  it("doesn't reset once next is called", function() {
+    let fixture = new ArrayUpdatable<number>(() => Observable.of([-1]));
+    fixture.next([42]);
+
+    let latest;
+    fixture.subscribe(x => latest = x);
+    expect(latest).to.deep.equal([42]);
+  });
+
+  it('should watch the array that we submit', function() {
+    const a = [1, 2, 3];
+    const fixture = new ArrayUpdatable<number>(() => Observable.of(a));
+
+    let changeList = fixture.createCollection();
+    expect(changeList.length).to.equal(1);
+
+    a.push(4);
+    Platform.performMicrotaskCheckpoint();
+    expect(changeList.length).to.equal(2);
+    expect(changeList[1]).to.deep.equal(a);
+
+    a.splice(0, 2);
+    Platform.performMicrotaskCheckpoint();
+    expect(changeList.length).to.equal(3);
+    expect(changeList[2]).to.deep.equal(a);
+
+    a.length = 0;
+    Platform.performMicrotaskCheckpoint();
+    expect(changeList.length).to.equal(4);
+    expect(changeList[3]).to.deep.equal(a);
+  });
+
+  it('should stop tracking one array when we give a new one', function() {
+    const a = [1, 2, 3];
+    const fixture = new ArrayUpdatable<number>(() => Observable.of(a));
+
+    let changeList = fixture.createCollection();
+    expect(changeList.length).to.equal(1);
+
+    a.push(4);
+    Platform.performMicrotaskCheckpoint();
+    expect(changeList.length).to.equal(2);
+    expect(changeList[1]).to.deep.equal(a);
+
+    const b = [4, 5, 6];
+    fixture.next(b);
+    expect(changeList.length).to.equal(3);
+    expect(changeList[2]).to.deep.equal(b);
+
+    a.push(5);
+    Platform.performMicrotaskCheckpoint();
+    expect(changeList.length).to.equal(3);
+    expect(changeList[2]).to.deep.equal(b);
   });
 });


### PR DESCRIPTION
This sprawling mess of a PR attempts to make collection views follow around an array, so that adding items to a View is as simple as `someModel.push()`. In order to do that, we use the `observe-js` library from Polymer which has the unfortunate caveat of, "after every array change, you need to call an extremely obscure `Platform.performMicrotaskCheckpoint()` method. This sucks out loud, we'll have to find a better solution.

This changes CollectionView to instead of requiring you to implement `rowCount`, you're required to provide the property name of your array in your ViewModel that you want to follow around. We'll observe if anyone tries to assign the array to a new one, and we'll also watch the array itself for changes - this means the React'y pattern of just paving the array every time still works. 

In order to make using arrays less special-case'y, we also introduce a new ArrayUpdatable class - it's just like Updatable, except:

* You can't use the `merge` strategy, sry
* Changing elements in the array will result in a `next` firing

This means that code that uses it can just pretend it's like any other Updatable and `toProperty` it, test it via:

```js
slackApp.store.joinedChannels.value.length = 0;
```

## TODO:

- [x] Make that above Compelling Example actually fucking work 
- [ ] Try to document the legions of issues we have around equality comparisons
- [x] Fix the tests