### PR TITLE
Enable branching type inference in union type param

### DIFF
--- a/src/lib/when.ts
+++ b/src/lib/when.ts
@@ -12,6 +12,7 @@ import './standard-operators';
 
 const identifier = /^[$A-Z_][0-9A-Z_$]*$/i;
 
+const typedIsFunction: (val: any) => val is Function = isFunction;
 export function whenPropertyInternal(target: any, valueOnly: boolean, ...propsAndSelector: Array<string|Function|string[]>): Observable<any> {
   if (propsAndSelector.length < 1) {
     throw new Error('Must specify at least one property!');
@@ -41,11 +42,10 @@ export function observableForPropertyChain(target: any, chain: (Array<string> | 
 
   if (Array.isArray(chain)) {
     props = chain;
-  } else if (isFunction(chain)) {
-    props = functionToPropertyChain(chain as Function);
+  } else if (typedIsFunction(chain)) {
+    props = functionToPropertyChain(chain);
   } else {
-    props = (chain as string).split('.');
-
+    props = chain.split('.');
     if (props.find((x) => x.match(identifier) === null)) {
       throw new Error("property name must be of the form 'foo.bar.baz'");
     }


### PR DESCRIPTION
This PR adds small amend for discussions enabling type inference for union type branches.

Few notes:
> why not `global-augument`?

: since `lodash.isFunction` is untyped module, so no `augumentation` is possible.

> name `typedIsFunction`

: I just picked random name for this, can apply any way you'd prefer. To preserve name, you could think to use `require` like below instead of import syntax.

```
const isFunction: (val: any) => val is Function = require('lodash.isFunction')....
```