### PR TITLE
Rewrite CollectionView to apply in more scenarios

### DIFF
--- a/src/channel-header.tsx
+++ b/src/channel-header.tsx
@@ -115,6 +115,7 @@ export class ChannelHeaderView extends SimpleView<ChannelHeaderViewModel> {
     return (
       <Popover
         open={this.viewModel.isMembersListOpen}
+        width={300} height={300}
         anchorEl={anchorElement}
         anchorOrigin={{ horizontal: 'middle', vertical: 'bottom' }}
         targetOrigin={{ horizontal: 'middle', vertical: 'top' }}
@@ -123,9 +124,6 @@ export class ChannelHeaderView extends SimpleView<ChannelHeaderViewModel> {
         <ChannelMembersView
           key={this.viewModel.channelInfo.name}
           viewModel={this.viewModel.channelMembers}
-          arrayProperty='members'
-          width={300}
-          height={300}
         />
       </Popover>
     );

--- a/src/channel-list-item.tsx
+++ b/src/channel-list-item.tsx
@@ -53,10 +53,7 @@ export class ChannelViewModel extends Model {
         // XXX: This is a crime
         let u = this.store.users.listen(c.user_id, c.api);
         return u.do(x => {
-          if (x && !x.profile) {
-            console.log(`No profile! ${JSON.stringify(x)}`);
-            u.invalidate();
-          }
+          if (x && !x.profile) { u.invalidate(); }
         });
       })
       .filter(x => x && !!x.profile)

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -5,7 +5,7 @@ import { AutoSizer, List } from 'react-virtualized';
 import { ChannelBase } from './lib/models/api-shapes';
 import { ChannelViewModel, ChannelListItem } from './channel-list-item';
 import { channelSort, isDM } from './lib/models/slack-api';
-import { CollectionView, ViewModelListHelper } from './lib/collection-view';
+import { ViewModelListHelper } from './lib/collection-view';
 import { fromObservable, notify, Model } from './lib/model';
 import { Store } from './lib/store';
 import { when } from './lib/when';
@@ -45,12 +45,18 @@ export class ChannelListView extends SimpleView<ChannelListViewModel> {
   constructor(props: { viewModel: ChannelListViewModel }, context?: any) {
     super(props, context);
 
-    this.lifecycle.didMount.subscribe(() => console.log("WAT"));
     this.viewModelCache = new ViewModelListHelper(
       this.lifecycle, props,
       (x: ChannelListViewModel) => x.orderedChannels,
       x => x.value.id,
       x => new ChannelViewModel(this.viewModel!, x));
+
+    const update = () => {
+      this.listRef.forceUpdateGrid();
+      this.forceUpdate();
+    };
+
+    this.viewModelCache.shouldRender.subscribe(() => this.queueUpdate(update));
   }
 
   rowRenderer({index, key, style}: {index: number, key: any, style: React.CSSProperties}) {
@@ -75,16 +81,5 @@ export class ChannelListView extends SimpleView<ChannelListViewModel> {
         />
       )}
     </AutoSizer>;
-  }
-}
-
-export class ChannelListViewOld extends CollectionView<ChannelListViewModel, ChannelViewModel> {
-  viewModelFactory(_item: any, index: number) {
-    const channel = this.viewModel.orderedChannels[index];
-    return new ChannelViewModel(this.viewModel, channel);
-  }
-
-  renderItem(viewModel: ChannelViewModel) {
-    return <ChannelListItem viewModel={viewModel} />;
   }
 }

--- a/src/channel-list.tsx
+++ b/src/channel-list.tsx
@@ -53,9 +53,11 @@ export class ChannelListView extends SimpleView<ChannelListViewModel> {
       x => new ChannelViewModel(this.viewModel!, x));
   }
 
-  rowRenderer({index, style}: {index: number, style: React.CSSProperties}) {
+  rowRenderer({index, key, style}: {index: number, key: any, style: React.CSSProperties}) {
     let vm = this.viewModelCache.getViewModel(index) as ChannelViewModel;
-    return <ChannelListItem key={vm.id} viewModel={vm} style={style} />;
+    return <div key={key} style={style}>
+      <ChannelListItem key={key} viewModel={vm} />;
+    </div>;
   }
 
   render() {

--- a/src/channel-members-view.tsx
+++ b/src/channel-members-view.tsx
@@ -1,32 +1,60 @@
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
+import { List } from 'react-virtualized';
 
 import { Api } from './lib/models/slack-api';
 import { UserViewModel, UserListItem } from './user-list-item';
-import { CollectionView } from './lib/collection-view';
+import { ViewModelListHelper } from './lib/collection-view';
 import { Model } from './lib/model';
-import { Store } from './store';
+import { Store } from './lib/store';
+import { HasViewModel, SimpleView } from './lib/view';
 
 export class ChannelMembersViewModel extends Model {
   constructor(
     public readonly store: Store,
     public readonly api: Api,
-    public readonly members: Array<string>
-  ) {
-    super();
-  }
+    public readonly members: Array<string>) { super(); }
 }
 
-export class ChannelMembersView extends CollectionView<ChannelMembersViewModel, UserViewModel> {
-  viewModelFactory(_item: any, index: number) {
-    return new UserViewModel(
-      this.viewModel.store,
-      this.viewModel.members[index],
-      this.viewModel.api
-    );
+export class ChannelMembersView extends SimpleView<ChannelMembersViewModel> {
+  viewModelCache: ViewModelListHelper<ChannelMembersViewModel, HasViewModel<ChannelMembersViewModel>, null>;
+  listRef: List;
+
+  constructor(props: { viewModel: ChannelMembersViewModel }, context?: any) {
+    super(props, context);
+
+    this.viewModelCache = new ViewModelListHelper(
+      this.lifecycle, props,
+      (x: ChannelMembersViewModel) => x.members,
+      x => x,
+      x => new UserViewModel(this.viewModel!.store, x, this.viewModel!.api));
+
+    const update = () => {
+      this.listRef.forceUpdateGrid();
+      this.forceUpdate();
+    };
+
+    this.viewModelCache.shouldRender.subscribe(() => this.queueUpdate(update));
   }
 
-  renderItem(viewModel: UserViewModel) {
-    return <UserListItem viewModel={viewModel} />;
+  rowRenderer({index, key, style}: {index: number, key: any, style: React.CSSProperties}) {
+    let vm = this.viewModelCache.getViewModel(index) as UserViewModel;
+
+    return <div key={key} style={style}>
+      <UserListItem viewModel={vm} />;
+    </div>;
+  }
+
+  render() {
+    let refBind = (l: List) => this.listRef = l;
+
+    return <List
+      ref={refBind}
+      width={300}
+      height={300}
+      rowHeight={32}
+      rowRenderer={this.rowRenderer.bind(this)}
+      rowCount={this.viewModelCache.getRowCount()}
+    />;
   }
 }

--- a/src/lib/collection-view.tsx
+++ b/src/lib/collection-view.tsx
@@ -1,23 +1,9 @@
-import * as React from 'react';
-import * as pick from 'lodash.pick';
-import { AutoSizer, List } from 'react-virtualized';
-import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
 import { Model } from './model';
-import { Lifecycle, View, HasViewModel } from './view';
-import { when, whenArray } from './when';
+import { Lifecycle, HasViewModel } from './view';
+import { whenArray } from './when';
 import * as LRU from 'lru-cache';
-
-export interface CollectionViewProps<T> {
-  viewModel: T;
-  arrayProperty: string;
-  rowHeight?: number;
-  width?: number;
-  height?: number;
-  disableWidth?: boolean;
-  disableHeight?: boolean;
-}
 
 export class ViewModelListHelper<T extends Model, P extends HasViewModel<T>, S> {
   readonly shouldRender: Subject<void>;
@@ -57,6 +43,7 @@ export class ViewModelListHelper<T extends Model, P extends HasViewModel<T>, S> 
 
     lifecycle.willUnmount.subscribe(() => {
       this.viewModelCache.reset();
+      this.shouldRender.unsubscribe();
       sub.unsubscribe();
     });
   }
@@ -78,109 +65,3 @@ export class ViewModelListHelper<T extends Model, P extends HasViewModel<T>, S> 
     return this.currentItems.length;
   }
 }
-
-/*
-export abstract class CollectionView<T extends Model, TChild extends Model>
-    extends View<T, CollectionViewProps<T>> {
-  private viewModelCache: { [key: number]: TChild } = {};
-  private listRef: List;
-
-  readonly lifecycle: Lifecycle<CollectionViewProps<T>, null>;
-
-  abstract viewModelFactory(item: any, index: number): TChild;
-  abstract renderItem(viewModel: TChild): JSX.Element;
-
-  static defaultProps = {
-    rowHeight: 32,
-    width: 300,
-    disableWidth: true
-  };
-
-  constructor(props?: CollectionViewProps<T>, context?: any) {
-    super(props, context);
-
-    const updater = () => {
-      if (!this.viewModel) return;
-      this.forceUpdate();
-
-      if (!this.listRef) return;
-      this.listRef.forceUpdateGrid();
-    };
-
-    this.lifecycle.willReceiveProps
-      .startWith(props)
-      .switchMap(x => x ? when(x.viewModel, x.arrayProperty) : Observable.never())
-      .takeUntil(this.lifecycle.willUnmount)
-      .subscribe(() => {
-        this.clearViewModelCache();
-        this.queueUpdate(updater);
-      }, (e) => setTimeout(() => { throw e; }, 10));
-
-    this.lifecycle.willUnmount.subscribe(() => {
-      this.clearViewModelCache();
-    });
-  }
-
-  clearViewModelCache() {
-    // TODO: It would be rull cool if we could reuse these in some sane way
-    Object.keys(this.viewModelCache).forEach(x => this.viewModelCache[x].unsubscribe());
-    this.viewModelCache = {};
-  }
-
-  getOrCreateViewModel(index: number): TChild {
-    if (!this.viewModelCache[index]) {
-      const arr: Array<any> = this.props.viewModel[this.props.arrayProperty];
-      const itemViewModel = this.viewModelFactory(arr[index], index);
-
-      itemViewModel.addTeardown(() => delete this.viewModelCache[index]);
-      this.viewModelCache[index] = itemViewModel;
-    }
-
-    return this.viewModelCache[index];
-  }
-
-  rowRenderer({ index, style }: { index: number, style: React.CSSProperties }) {
-    return (
-      <div key={index} style={style}>
-        {this.renderItem(this.getOrCreateViewModel(index))}
-      </div>
-    );
-  }
-
-  rowCount() {
-    const arr: Array<any> = this.props.viewModel[this.props.arrayProperty];
-    return arr.length;
-  }
-
-  render() {
-    const autoSizerProps = pick(this.props, ['disableWidth', 'disableHeight']);
-    const listProps = pick(this.props, ['width', 'height', 'rowHeight']);
-
-    if (listProps.width && listProps.height) {
-      return (
-        <List
-          {...listProps}
-          rowRenderer={this.rowRenderer.bind(this)}
-          rowCount={this.rowCount()}
-        />
-      );
-    }
-
-    let refBind = ((l: List) => this.listRef = l).bind(this);
-    return (
-      <AutoSizer {...autoSizerProps}>
-        {({ width, height }: { width: number, height: number }) => (
-          <List
-            ref={refBind}
-            width={width}
-            height={height}
-            {...listProps}
-            rowRenderer={this.rowRenderer.bind(this)}
-            rowCount={this.rowCount()}
-          />
-        )}
-      </AutoSizer>
-    );
-  }
-}
-*/

--- a/src/lib/when.ts
+++ b/src/lib/when.ts
@@ -44,7 +44,7 @@ export type ArrayChange<T> = { value: T[], splices: splice[] };
 export function whenArray<TSource, TProp>(
     target: TSource,
     prop: (t: TSource) => TProp[]): Observable<ArrayChange<TProp>> {
-  return when(target, prop).switchMap(observeArray);
+  return when(target, prop).switchMap(x => observeArray(x).startWith({ value: x, splices: []}));
 }
 
 export function observeArray<T>(arr: T[]): Observable<ArrayChange<T>> {


### PR DESCRIPTION
This PR replaces CollectionView into a new class, `ViewModelListHelper`, which tries to extract the benefits of CollectionView without implementing `render()` ourselves, since most people will have to override it anyways.

Instead, we'll have a class that manages ViewModels for us by watching an array, and let the View actually set up the list. This PR also solves some race conditions where ViewModels would end up getting disposed, as well as sets up a framework for being able to reuse ViewModels instead of CollectionView, which :fire:d the entire list whenever the array changed.

## TODO:

- [ ] See if we can get rid of some of the boilerplate
- [x] Move Messages over