### PR TITLE
Make React re-render less and not so glitchy-like

### DIFF
--- a/.compilerc
+++ b/.compilerc
@@ -24,7 +24,7 @@
         "inlineSources": true,
         "noUnusedParameters": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "ESNext",
         "sourceMap": false,
         "jsx": "react",
         "types": [
@@ -59,7 +59,7 @@
         "noUnusedParameters": true,
         "module": "commonjs",
         "sourceMap": false,
-        "target": "es5",
+        "target": "ESNext",
         "jsx": "react",
         "types": [
           "node"
@@ -89,7 +89,7 @@
         "noUnusedParameters": true,
         "sourceMap": false,
         "module": "commonjs",
-        "target": "es5",
+        "target": "ESNext",
         "jsx": "react",
         "types": [
           "node"

--- a/.compilerc
+++ b/.compilerc
@@ -24,7 +24,7 @@
         "inlineSources": true,
         "noUnusedParameters": true,
         "module": "commonjs",
-        "target": "ESNext",
+        "target": "es5",
         "sourceMap": false,
         "jsx": "react",
         "types": [

--- a/src/lib/dexie-data-model.ts
+++ b/src/lib/dexie-data-model.ts
@@ -3,7 +3,7 @@ import { AsyncSubject } from 'rxjs/AsyncSubject';
 import Dexie from 'dexie';
 import { asyncMap } from './promise-extras';
 import { User, ChannelBase, Message } from './models/api-shapes';
-import { Pair } from './utils';
+import { Pair, queueDeferredAction } from './utils';
 import { Api } from './models/slack-api';
 
 import './standard-operators';
@@ -88,7 +88,7 @@ function deferredPut<T, Key>(this: Dexie.Table<T, Key>, item: T & Api, key: Key)
 function deferredGet<T, Key>(this: Dexie.Table<T, Key>, key: Key, database: Dexie): Promise<T> {
   let newItem = { key, completion: new AsyncSubject<T>() };
 
-  let createIdle = () => window.requestAnimationFrame(async () => {
+  let createIdle = () => queueDeferredAction(async () => {
     let itemsToGet = this.deferredGets;
     this.deferredGets = [];
 
@@ -121,7 +121,7 @@ function deferredGet<T, Key>(this: Dexie.Table<T, Key>, key: Key, database: Dexi
     }
 
     if (this.deferredGets.length > 0) {
-      this.idleGetHandle = createIdle();
+      queueDeferredAction(createIdle);
     }
   });
 

--- a/src/lib/standard-operators.ts
+++ b/src/lib/standard-operators.ts
@@ -14,6 +14,7 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/concat';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/finally';
 import 'rxjs/add/operator/groupBy';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,6 +40,12 @@ function createDeferredAction() {
   if (currentRafToken) return;
   if (hasFocus === undefined) hasFocus = document.hasFocus();
 
+  if (isInTestRunner) {
+    currentRafToken = 1;
+    dispatchDeferredActions();
+    return;
+  }
+
   currentRafToken = hasFocus ?
     requestAnimationFrame(dispatchDeferredActions) :
     window.setTimeout(dispatchDeferredActions, 20);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { Subscription } from 'rxjs/Subscription';
+
 export type Pair<K, V> = { Key: K, Value: V };
 
 export function captureStack(): string {
@@ -7,4 +9,51 @@ export function captureStack(): string {
 export function detectTestRunner() {
   let stack = captureStack();
   return !!stack.split('\n').find(x => !!x.match(/[\\\/](enzyme|mocha)[\\\/]/i));
+}
+
+export type deferredAction = (() => Promise<void> | void);
+
+let hasFocus: boolean | undefined;
+let isInTestRunner: boolean;
+let currentRafToken: number | undefined;
+let deferredItemQueue: Array<{ action: deferredAction, cancelled: boolean }> = [];
+
+function dispatchDeferredActions() {
+  let start = performance.now();
+  try {
+    while(deferredItemQueue.length > 0) {
+      let item = deferredItemQueue.shift()!;
+      if (item.cancelled) continue;
+
+      item.action();
+      if (performance.now() - start > 250) break;
+    }
+  } finally {
+    hasFocus = undefined;
+    currentRafToken = undefined;
+  }
+
+  if (deferredItemQueue.length > 0) createDeferredAction();
+}
+
+function createDeferredAction() {
+  if (currentRafToken) return;
+  if (hasFocus === undefined) hasFocus = document.hasFocus();
+
+  currentRafToken = hasFocus ?
+    requestAnimationFrame(dispatchDeferredActions) :
+    window.setTimeout(dispatchDeferredActions, 20);
+}
+
+export function queueDeferredAction(action: deferredAction): Subscription {
+  // NB: We have to check this here because we use the call stack to determine this
+  if (isInTestRunner === undefined) {
+    isInTestRunner = detectTestRunner();
+  }
+
+  let toAdd = { action, cancelled: false };
+  deferredItemQueue.push(toAdd);
+
+  createDeferredAction();
+  return new Subscription(() => toAdd.cancelled = true);
 }

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -129,6 +129,7 @@ export abstract class View<T extends Model, P extends HasViewModel<T>>
       .switchMap(() => this.viewModel ? this.viewModel.changed : Observable.never())
       .do(() => this.changeIndex++)
       .takeUntil(this.lifecycle.willUnmount)
+      .debounceTime(10)
       .subscribe(() => { if (this.viewModel) { this.queueUpdate(customUpdater); } });
 
     this.lifecycle.willUpdate.subscribe(() => this.renderIndex = this.changeIndex);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "pretty": true,
-    "target": "es6",
+    "target": "ESNext",
     "jsx": "react",
     "outDir": ".tmp/build"
   },


### PR DESCRIPTION
This PR retools some of our deferred rendering to avoid lock convoy-like behavior - consider the following super-ass common scenario:

1. We request some data
1. It gets thrown in the deferred get queue for IndexedDb
1. Data comes back, we need to render the associated view
1. We get deferred *again*, in the deferred forceUpdate queue

Instead, let's just have a unified queue that will keep running if items themselves queue work.

This PR also upgrades code generation to not polyfill the world, which gets rid of all of those manual TypeScript awaiters

## TODO:

- [x] Merge #62 first
- [ ] Fix the tests